### PR TITLE
Replace Reflections with ClassGraph for classpath scanning

### DIFF
--- a/graphql-builder/pom.xml
+++ b/graphql-builder/pom.xml
@@ -56,9 +56,9 @@
             <version>24.0</version>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.10.2</version>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.179</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
@@ -19,17 +19,16 @@ import graphql.schema.GraphQLSchema;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import jakarta.validation.Constraint;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import jakarta.validation.Constraint;
-import org.reflections.Reflections;
-import org.reflections.scanners.Scanners;
-
-import static org.reflections.scanners.Scanners.SubTypes;
 
 public class SchemaBuilder {
 
@@ -141,59 +140,93 @@ public class SchemaBuilder {
 			try {
 				this.scalar(ExtendedScalars.GraphQLLong);
 
-				Reflections reflections = new Reflections(classpaths, SubTypes, Scanners.MethodsAnnotated, Scanners.TypesAnnotated);
-				Set<Class<? extends Authorizer>> authorizers = reflections.getSubTypesOf(Authorizer.class);
-				// want to make everything split by package
-				AuthorizerSchema authorizer = AuthorizerSchema.build(dataFetcherRunner, new HashSet<>(classpaths), authorizers);
+				try (ScanResult scanResult = new ClassGraph()
+					.acceptPackages(classpaths.toArray(String[]::new))
+					.enableClassInfo()
+					.enableMethodInfo()
+					.enableAnnotationInfo()
+					.scan()) {
 
-				Set<Class<? extends SchemaConfiguration>> schemaConfiguration = reflections.getSubTypesOf(SchemaConfiguration.class);
+					Set<Class<? extends Authorizer>> authorizers = new HashSet<>(
+						scanResult.getClassesImplementing(Authorizer.class).loadClasses(Authorizer.class)
+					);
+					// want to make everything split by package
+					AuthorizerSchema authorizer = AuthorizerSchema.build(dataFetcherRunner, new HashSet<>(classpaths), authorizers);
 
-				DirectivesSchema directivesSchema = getDirectivesSchema(reflections);
+					Set<Class<? extends SchemaConfiguration>> schemaConfiguration = new HashSet<>(
+						scanResult.getClassesImplementing(SchemaConfiguration.class).loadClasses(SchemaConfiguration.class)
+					);
 
-				Set<Class<?>> types = reflections.getTypesAnnotatedWith(Entity.class);
+					DirectivesSchema directivesSchema = getDirectivesSchema(scanResult);
 
-				var mutations = reflections.getMethodsAnnotatedWith(Mutation.class);
-				var subscriptions = reflections.getMethodsAnnotatedWith(Subscription.class);
-				var queries = reflections.getMethodsAnnotatedWith(Query.class);
+					var entityClasses = scanResult.getClassesWithAnnotation(Entity.class).loadClasses();
+					entityClasses.removeIf(t -> t.getDeclaredAnnotation(Entity.class) == null);
+					entityClasses.removeIf(Class::isAnonymousClass);
+					// Sort: BOTH/INPUT types first so they claim entity registry slots before TYPE-only
+					// types when multiple classes share the same simple name across packages
+					entityClasses.sort((a, b) -> {
+						SchemaOption aVal = a.getDeclaredAnnotation(Entity.class).value();
+						SchemaOption bVal = b.getDeclaredAnnotation(Entity.class).value();
+						int aScore = (aVal == SchemaOption.TYPE) ? 1 : 0;
+						int bScore = (bVal == SchemaOption.TYPE) ? 1 : 0;
+						if (aScore != bScore) return aScore - bScore;
+						return a.getCanonicalName().compareTo(b.getCanonicalName());
+					});
+					Set<Class<?>> types = new LinkedHashSet<>(entityClasses);
 
-				var endPoints = new HashSet<>(mutations);
-				endPoints.addAll(subscriptions);
-				endPoints.addAll(queries);
+					var mutations = getMethodsAnnotatedWith(scanResult, Mutation.class);
+					var subscriptions = getMethodsAnnotatedWith(scanResult, Subscription.class);
+					var queries = getMethodsAnnotatedWith(scanResult, Query.class);
 
-				types.removeIf(t -> t.getDeclaredAnnotation(Entity.class) == null);
-				types.removeIf(Class::isAnonymousClass);
+					var endPoints = new HashSet<>(mutations);
+					endPoints.addAll(subscriptions);
+					endPoints.addAll(queries);
 
-				return new SchemaBuilder(dataFetcherRunner, scalars, directivesSchema, authorizer)
-					.processTypes(types)
-					.process(endPoints, shouldValidate)
-					.build(schemaConfiguration);
+					return new SchemaBuilder(dataFetcherRunner, scalars, directivesSchema, authorizer)
+						.processTypes(types)
+						.process(endPoints, shouldValidate)
+						.build(schemaConfiguration);
+				}
 			} catch (ReflectiveOperationException e) {
 				throw new RuntimeException(e);
 			}
 		}
 
-		private static DirectivesSchema getDirectivesSchema(Reflections reflections) throws ReflectiveOperationException {
-			Set<Class<?>> directivesTypes = reflections.getTypesAnnotatedWith(Directive.class);
-			directivesTypes.addAll(reflections.getTypesAnnotatedWith(DataFetcherWrapper.class));
+		private static Set<Method> getMethodsAnnotatedWith(ScanResult scanResult, Class<? extends Annotation> annotation) {
+			Set<Method> methods = new HashSet<>();
+			for (var classInfo : scanResult.getClassesWithMethodAnnotation(annotation)) {
+				for (Method method : classInfo.loadClass().getMethods()) {
+					if (method.isAnnotationPresent(annotation)) {
+						methods.add(method);
+					}
+				}
+			}
+			return methods;
+		}
 
-			List<RestrictTypeFactory<?>> globalRestricts = getGlobalRestricts(reflections);
+		private static DirectivesSchema getDirectivesSchema(ScanResult scanResult) throws ReflectiveOperationException {
+			Set<Class<?>> directivesTypes = new HashSet<>(scanResult.getClassesWithAnnotation(Directive.class).loadClasses());
+			directivesTypes.addAll(scanResult.getClassesWithAnnotation(DataFetcherWrapper.class).loadClasses());
+
+			List<RestrictTypeFactory<?>> globalRestricts = getGlobalRestricts(scanResult);
 
 			return DirectivesSchema.build(globalRestricts, directivesTypes, getJakartaAnnotations());
 		}
 
 		private static Set<Class<?>> getJakartaAnnotations() {
-			Reflections reflections = new Reflections("jakarta.validation.constraints", SubTypes.filterResultsBy(c -> true));
-			return reflections
-				.getSubTypesOf(Object.class)
-				.stream()
-				.filter(a -> a.isAnnotationPresent(Constraint.class))
-				.collect(Collectors.toSet());
+			try (ScanResult scanResult = new ClassGraph()
+				.acceptPackages("jakarta.validation.constraints")
+				.enableClassInfo()
+				.enableAnnotationInfo()
+				.scan()) {
+				return new HashSet<>(scanResult.getClassesWithAnnotation(Constraint.class).loadClasses());
+			}
 		}
 
-		private static List<RestrictTypeFactory<?>> getGlobalRestricts(Reflections reflections)
+		private static List<RestrictTypeFactory<?>> getGlobalRestricts(ScanResult scanResult)
 			throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-			Set<Class<?>> restrict = reflections.getTypesAnnotatedWith(Restrict.class);
-			Set<Class<?>> restricts = reflections.getTypesAnnotatedWith(Restricts.class);
+			Set<Class<?>> restrict = new HashSet<>(scanResult.getClassesWithAnnotation(Restrict.class).loadClasses());
+			Set<Class<?>> restricts = new HashSet<>(scanResult.getClassesWithAnnotation(Restricts.class).loadClasses());
 			List<RestrictTypeFactory<?>> globalRestricts = new ArrayList<>();
 
 			for (var r : restrict) {

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeMeta.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeMeta.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import org.reactivestreams.Publisher;
 
 public class TypeMeta {
@@ -163,7 +163,7 @@ public class TypeMeta {
 	}
 
 	private void process(Class<?> type, Type genericType, AnnotatedElement element) {
-		if (element != null && (element.isAnnotationPresent(Nullable.class) || element.isAnnotationPresent(jakarta.annotation.Nullable.class))) {
+		if (element != null && element.isAnnotationPresent(Nullable.class)) {
 			if (!flags.contains(Flag.OPTIONAL)) {
 				flags.add(Flag.OPTIONAL);
 			}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/record/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/record/Queries.java
@@ -18,7 +18,7 @@ import com.phocassoftware.graphql.builder.annotations.Union;
 
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 public class Queries {
 

--- a/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
+++ b/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
@@ -63,7 +63,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.reflections.Reflections;
+import io.github.classgraph.ClassGraph;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -152,7 +152,10 @@ public class DynamoDb extends DatabaseDriver {
 		this.parallelHashIndex = parallelHashIndex;
 
 		if (classPath != null) {
-			var tableObjects = new Reflections(classPath).getSubTypesOf(Table.class);
+			java.util.List<Class<Table>> tableObjects;
+			try (var scanResult = new ClassGraph().acceptPackages(classPath).enableClassInfo().scan()) {
+				tableObjects = scanResult.getSubclasses(Table.class).loadClasses(Table.class);
+			}
 
 			this.hashKeyExpander = new HashMap<>();
 			this.classes = new HashMap<>();
@@ -987,8 +990,11 @@ public class DynamoDb extends DatabaseDriver {
 			throw new RuntimeException("classPath is required to obtain the tables' name to query the history table");
 		}
 
-		// Using reflections to loop through tables and get the tables' name
-		Set<Class<? extends Table>> tableObjects = new Reflections(classPath).getSubTypesOf(Table.class);
+		// Using classgraph to loop through tables and get the tables' name
+		java.util.List<Class<Table>> tableObjects;
+		try (var scanResult = new ClassGraph().acceptPackages(classPath).enableClassInfo().scan()) {
+			tableObjects = scanResult.getSubclasses(Table.class).loadClasses(Table.class);
+		}
 		List<HistoryBackupItem> toReturn = Collections.synchronizedList(new ArrayList<HistoryBackupItem>());
 
 		Set<String> orgIdTypes = tableObjects.stream().map(obj -> organisationId + ":" + TableCoreUtil.table(obj)).collect(Collectors.toSet());


### PR DESCRIPTION
## Summary

- Replace `org.reflections:reflections:0.10.2` with `io.github.classgraph:classgraph:4.8.179`
- Rewrite `SchemaBuilder` and `DynamoDb` classpath scanning to use ClassGraph API
- Migrate `javax.annotation.Nullable` → `jakarta.annotation.Nullable` (was only available via reflections→guava transitive dep)

## Changes

**`SchemaBuilder.java`**
- `new Reflections(pkgs, scanners)` → `ClassGraph().acceptPackages(...).enableClassInfo/MethodInfo/AnnotationInfo().scan()`
- `getSubTypesOf(Interface)` → `getClassesImplementing(Interface)`
- `getTypesAnnotatedWith(Annotation)` → `getClassesWithAnnotation(Annotation)`
- `getMethodsAnnotatedWith(Annotation)` → new helper using `getClassesWithMethodAnnotation` + reflection
- Entity types sorted (BOTH/INPUT before TYPE) for deterministic registration order when classes in different packages share the same simple name

**`DynamoDb.java`**
- Two `new Reflections(pkg).getSubTypesOf(Table.class)` calls replaced with `ClassGraph` scan using `getSubclasses(Table.class)`

**`TypeMeta.java` / `Queries.java`**
- `import javax.annotation.Nullable` → `import jakarta.annotation.Nullable`

## Test plan
- [x] All 299 tests pass (`mvn test`)
- [x] Formatter check passes (`mvn formatter:validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)