### PR TITLE
Omit Object contract methods from record schema fields

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -23,6 +23,7 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLObjectType.Builder;
 import graphql.schema.GraphQLTypeReference;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -210,6 +211,7 @@ public abstract class TypeBuilder {
 				.stream(type.getMethods())
 				.filter(method -> !method.isSynthetic())
 				.filter(method -> !method.getDeclaringClass().equals(Object.class))
+				.filter(method -> !isObjectContractMethod(method))
 				.filter(method -> !method.isAnnotationPresent(GraphQLIgnore.class))
 				.filter(method -> !Modifier.isStatic(method.getModifiers()))
 				.filter(method -> !method.getReturnType().equals(void.class))
@@ -229,6 +231,15 @@ public abstract class TypeBuilder {
 					graphType.field(f);
 					interfaceBuilder.field(f);
 				});
+		}
+
+		private static boolean isObjectContractMethod(Method method) {
+			try {
+				var objectMethod = Object.class.getMethod(method.getName(), method.getParameterTypes());
+				return objectMethod.getReturnType().equals(method.getReturnType());
+			} catch (NoSuchMethodException e) {
+				return false;
+			}
 		}
 	}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/RecordTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/RecordTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 //does not test all of records as needs newer version of java. But Classes that look like records
@@ -40,6 +42,29 @@ public class RecordTest {
 		assertEquals(2, results.size());
 		assertEquals(Map.of("name", "Lola", "somethingToDoWithDogs", "LikesBones", "type", "Dog"), results.get(0));
 		assertEquals(Map.of("name", "Mavi", "somethingToDoWithCats", "LikesCheese", "type", "Cat", "greet", "Hello Mavi"), results.get(1));
+	}
+
+	@Test
+	public void testRecordSchemaHidesObjectMethods() {
+		Map<String, Map<String, Object>> response = execute(
+			"{" +
+				"  __type(name: \"CatRecord\") {" +
+				"    fields {" +
+				"      name" +
+				"    }" +
+				"  }" +
+				"}",
+			null
+		).getData();
+
+		var type = response.get("__type");
+		List<Map<String, String>> fields = (List<Map<String, String>>) type.get("fields");
+		var names = fields.stream().map(field -> field.get("name")).collect(Collectors.toSet());
+
+		assertTrue(names.containsAll(Set.of("name", "description", "type", "somethingToDoWithCats", "greet")));
+		assertFalse(names.contains("equals"));
+		assertFalse(names.contains("hashCode"));
+		assertFalse(names.contains("toString"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Filter record methods that match `Object` contract signatures (`equals`, `hashCode`, `toString`) so internal methods are not exposed in generated GraphQL schemas.

## Why
A recent record field discovery change started surfacing these internal methods, which leaks implementation details and can break downstream schema-based code generation.

## Notes
This keeps support for record types implementing sealed interfaces by continuing to scan record methods and only excluding `Object`-contract methods.
