### PR TITLE
DS-807 support interfaces as GraphQL union output types

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
@@ -66,28 +66,36 @@ public class EntityProcessor {
 		for (var scalar : scalars) {
 			var coercing = scalar.getCoercing();
 			var type = coercing.getClass();
-			for (var method : type.getMethods()) {
-				if (method.isSynthetic()) {
-					continue;
+			Class<?> returnType = resolveScalarType(type);
+			if (returnType != null && !returnType.equals(Object.class)) {
+				if (returnType.equals(Long.class)) {
+					put(Long.TYPE, new ScalarEntity(scalar));
+				} else if (returnType.equals(Byte.class)) {
+					put(Byte.TYPE, new ScalarEntity(scalar));
+				} else if (returnType.equals(Character.class)) {
+					put(Character.TYPE, new ScalarEntity(scalar));
+				} else if (returnType.equals(Float.class)) {
+					put(Float.TYPE, new ScalarEntity(scalar));
+				} else if (returnType.equals(Short.class)) {
+					put(Short.TYPE, new ScalarEntity(scalar));
 				}
-				if ("parseValue".equals(method.getName())) {
-					var returnType = method.getReturnType();
-					if (returnType.equals(Long.class)) {
-						put(Long.TYPE, new ScalarEntity(scalar));
-					} else if (returnType.equals(Byte.class)) {
-						put(Byte.TYPE, new ScalarEntity(scalar));
-					} else if (returnType.equals(Character.class)) {
-						put(Character.TYPE, new ScalarEntity(scalar));
-					} else if (returnType.equals(Float.class)) {
-						put(Float.TYPE, new ScalarEntity(scalar));
-					} else if (returnType.equals(Short.class)) {
-						put(Short.TYPE, new ScalarEntity(scalar));
-					}
-					put(returnType, new ScalarEntity(scalar));
-					break;
-				}
+				put(returnType, new ScalarEntity(scalar));
 			}
 		}
+	}
+
+	private static Class<?> resolveScalarType(Class<?> coercingClass) {
+		Class<?> best = null;
+		for (var method : coercingClass.getMethods()) {
+			if (method.isSynthetic()) continue;
+			if (!"parseValue".equals(method.getName())) continue;
+			var returnType = method.getReturnType();
+			if (returnType.equals(Object.class)) continue;
+			if (best == null || method.getDeclaringClass() != Object.class) {
+				best = returnType;
+			}
+		}
+		return best;
 	}
 
 	private void put(Class<?> type, ScalarEntity entity) {
@@ -118,9 +126,16 @@ public class EntityProcessor {
 						if (type.isAnnotationPresent(Scalar.class)) {
 							return new ScalarEntity(directives, meta);
 						}
+						var packageName = type.getPackageName();
+						if (packageName.startsWith("java.") || packageName.startsWith("javax.") || packageName.startsWith("jakarta.")) {
+							return new ScalarEntity(Scalars.GraphQLString);
+						}
 						if (type.isEnum()) {
 							return new EnumEntity(directives, meta);
 						} else {
+							if (type.isInterface() && !type.isAnnotationPresent(com.phocassoftware.graphql.builder.annotations.OneOf.class)) {
+								return new ScalarEntity(Scalars.GraphQLString);
+							}
 							return new ObjectEntity(this, meta);
 						}
 					} catch (ReflectiveOperationException | RuntimeException e) {

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
@@ -25,7 +25,9 @@ import graphql.schema.GraphQLType;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +42,10 @@ public class EntityProcessor {
 	private final Map<String, EntityHolder> entities;
 	private final MethodProcessor methodProcessor;
 
+	// All @Entity-annotated classes discovered during the scan. Used to find the implementations of an
+	// interface so it can be represented as a union, even when the interface is not sealed.
+	private Set<Class<?>> entityTypes = Set.of();
+
 	EntityProcessor(DataFetcherRunner dataFetcherRunner, List<GraphQLScalarType> scalars, DirectivesSchema directives) {
 		this.methodProcessor = new MethodProcessor(dataFetcherRunner, this, directives);
 		this.entities = new HashMap<>();
@@ -47,6 +53,33 @@ public class EntityProcessor {
 		addScalars(scalars);
 
 		this.directives = directives;
+	}
+
+	void setEntityTypes(Set<Class<?>> entityTypes) {
+		this.entityTypes = entityTypes;
+	}
+
+	/**
+	 * Returns the concrete @Entity classes that implement the given interface, used as the members of the
+	 * union generated for that interface.
+	 */
+	List<Class<?>> getImplementations(Class<?> interfaceType) {
+		var implementations = new ArrayList<Class<?>>();
+		var permitted = interfaceType.getPermittedSubclasses();
+		if (permitted != null) {
+			for (var subType : permitted) {
+				implementations.add(subType);
+			}
+		}
+		for (var candidate : entityTypes) {
+			if (candidate == interfaceType || candidate.isInterface() || Modifier.isAbstract(candidate.getModifiers())) {
+				continue;
+			}
+			if (interfaceType.isAssignableFrom(candidate) && !implementations.contains(candidate)) {
+				implementations.add(candidate);
+			}
+		}
+		return implementations;
 	}
 
 	private void addDefaults() {
@@ -133,9 +166,6 @@ public class EntityProcessor {
 						if (type.isEnum()) {
 							return new EnumEntity(directives, meta);
 						} else {
-							if (type.isInterface() && !type.isAnnotationPresent(com.phocassoftware.graphql.builder.annotations.OneOf.class)) {
-								return new ScalarEntity(Scalars.GraphQLString);
-							}
 							return new ObjectEntity(this, meta);
 						}
 					} catch (ReflectiveOperationException | RuntimeException e) {

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
@@ -108,6 +108,32 @@ class EntityUtil {
 		return Optional.empty();
 	}
 
+	/**
+	 * Whether {@code type} exposes any GraphQL fields, i.e. declares a getter-style method. A field-less
+	 * interface cannot be a GraphQL interface type (which requires at least one field), so it is represented
+	 * as a union of its implementations instead.
+	 */
+	static boolean hasFields(Class<?> type) {
+		for (var method : type.getMethods()) {
+			if (method.isSynthetic()) {
+				continue;
+			}
+			if (method.getDeclaringClass().equals(Object.class)) {
+				continue;
+			}
+			if (Modifier.isStatic(method.getModifiers())) {
+				continue;
+			}
+			if (method.isAnnotationPresent(GraphQLIgnore.class)) {
+				continue;
+			}
+			if (method.getParameterCount() == 0 && method.getName().matches("(get|is)[A-Z].*")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public static Optional<String> setter(Method method) {
 		if (method.isSynthetic()) {
 			return Optional.empty();

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
@@ -24,8 +24,8 @@ public class ObjectEntity extends EntityHolder {
 	private TypeBuilder typeBuilder;
 
 	public ObjectEntity(EntityProcessor entityProcessor, TypeMeta meta) {
-		if (meta.getType().isInterface() && meta.getType().isAnnotationPresent(OneOf.class)) {
-			typeBuilder = new TypeBuilder.OneOfUnion(entityProcessor, meta);
+		if (meta.getType().isInterface()) {
+			typeBuilder = new TypeBuilder.InterfaceUnion(entityProcessor, meta);
 		} else if (meta.getType().isRecord()) {
 			typeBuilder = new TypeBuilder.Record(entityProcessor, meta);
 		} else {

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
@@ -24,7 +24,7 @@ public class ObjectEntity extends EntityHolder {
 	private TypeBuilder typeBuilder;
 
 	public ObjectEntity(EntityProcessor entityProcessor, TypeMeta meta) {
-		if (meta.getType().isInterface()) {
+		if (meta.getType().isInterface() && !EntityUtil.hasFields(meta.getType())) {
 			typeBuilder = new TypeBuilder.InterfaceUnion(entityProcessor, meta);
 		} else if (meta.getType().isRecord()) {
 			typeBuilder = new TypeBuilder.Record(entityProcessor, meta);

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/ObjectEntity.java
@@ -24,7 +24,9 @@ public class ObjectEntity extends EntityHolder {
 	private TypeBuilder typeBuilder;
 
 	public ObjectEntity(EntityProcessor entityProcessor, TypeMeta meta) {
-		if (meta.getType().isRecord()) {
+		if (meta.getType().isInterface() && meta.getType().isAnnotationPresent(OneOf.class)) {
+			typeBuilder = new TypeBuilder.OneOfUnion(entityProcessor, meta);
+		} else if (meta.getType().isRecord()) {
 			typeBuilder = new TypeBuilder.Record(entityProcessor, meta);
 		} else {
 			typeBuilder = new TypeBuilder.ObjectType(entityProcessor, meta);

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
@@ -46,6 +46,7 @@ public class SchemaBuilder {
 	}
 
 	private SchemaBuilder processTypes(Set<Class<?>> types) {
+		this.entityProcessor.setEntityTypes(types);
 		for (var type : types) {
 			TypeMeta meta = new TypeMeta(null, type, type);
 

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -14,7 +14,6 @@ package com.phocassoftware.graphql.builder;
 import com.phocassoftware.graphql.builder.annotations.Entity;
 import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;
 import com.phocassoftware.graphql.builder.annotations.GraphQLIgnore;
-import com.phocassoftware.graphql.builder.annotations.OneOf;
 import com.phocassoftware.graphql.builder.exceptions.DuplicateMethodNameException;
 import graphql.schema.GraphQLUnionType;
 import graphql.introspection.Introspection;
@@ -251,26 +250,34 @@ public abstract class TypeBuilder {
 		}
 	}
 
-	public static class OneOfUnion extends TypeBuilder {
+	/** Represents an interface as a union of its implementations (permitted subclasses or @Entity implementers). */
+	public static class InterfaceUnion extends TypeBuilder {
 
-		public OneOfUnion(EntityProcessor entityProcessor, TypeMeta meta) {
+		public InterfaceUnion(EntityProcessor entityProcessor, TypeMeta meta) {
 			super(entityProcessor, meta);
 		}
 
 		@Override
 		public GraphQLNamedOutputType buildType() {
-			var oneOf = meta.getType().getAnnotation(OneOf.class);
+			var type = meta.getType();
 			var name = EntityUtil.getName(meta);
 			var builder = GraphQLUnionType.newUnionType();
 			builder.name(name);
 
-			var description = meta.getType().getAnnotation(GraphQLDescription.class);
+			var description = type.getAnnotation(GraphQLDescription.class);
 			if (description != null) {
 				builder.description(description.value());
 			}
 
-			for (var oneOfType : oneOf.value()) {
-				var possible = entityProcessor.getEntity(oneOfType.type()).getInnerType(new TypeMeta(null, oneOfType.type(), oneOfType.type()));
+			var members = entityProcessor.getImplementations(type);
+			if (members.isEmpty()) {
+				throw new RuntimeException(
+					"Interface " + type.getName() + " cannot be used as an output type: no implementations were found to form its union. " +
+						"Make it a sealed interface, or annotate its implementations with @Entity."
+				);
+			}
+			for (var member : members) {
+				var possible = entityProcessor.getEntity(member).getInnerType(new TypeMeta(null, member, member));
 				builder.possibleType(GraphQLTypeReference.typeRef(possible.getName()));
 			}
 
@@ -279,14 +286,12 @@ public abstract class TypeBuilder {
 				.typeResolver(
 					name,
 					env -> {
-						for (var oneOfType : oneOf.value()) {
-							if (oneOfType.type().isInstance(env.getObject())) {
-								return (GraphQLObjectType) entityProcessor
-									.getEntity(oneOfType.type())
-									.getInnerType(new TypeMeta(null, oneOfType.type(), oneOfType.type()));
+						for (var member : members) {
+							if (member.isInstance(env.getObject())) {
+								return (GraphQLObjectType) entityProcessor.getEntity(member).getInnerType(new TypeMeta(null, member, member));
 							}
 						}
-						throw new RuntimeException("OneOf " + name + " does not support type " + env.getObject().getClass().getSimpleName());
+						throw new RuntimeException("Union " + name + " does not support type " + env.getObject().getClass().getSimpleName());
 					}
 				);
 

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -14,7 +14,9 @@ package com.phocassoftware.graphql.builder;
 import com.phocassoftware.graphql.builder.annotations.Entity;
 import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;
 import com.phocassoftware.graphql.builder.annotations.GraphQLIgnore;
+import com.phocassoftware.graphql.builder.annotations.OneOf;
 import com.phocassoftware.graphql.builder.exceptions.DuplicateMethodNameException;
+import graphql.schema.GraphQLUnionType;
 import graphql.introspection.Introspection;
 import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLInterfaceType;
@@ -246,6 +248,53 @@ public abstract class TypeBuilder {
 			} catch (NoSuchMethodException e) {
 				return false;
 			}
+		}
+	}
+
+	public static class OneOfUnion extends TypeBuilder {
+
+		public OneOfUnion(EntityProcessor entityProcessor, TypeMeta meta) {
+			super(entityProcessor, meta);
+		}
+
+		@Override
+		public GraphQLNamedOutputType buildType() {
+			var oneOf = meta.getType().getAnnotation(OneOf.class);
+			var name = EntityUtil.getName(meta);
+			var builder = GraphQLUnionType.newUnionType();
+			builder.name(name);
+
+			var description = meta.getType().getAnnotation(GraphQLDescription.class);
+			if (description != null) {
+				builder.description(description.value());
+			}
+
+			for (var oneOfType : oneOf.value()) {
+				var possible = entityProcessor.getEntity(oneOfType.type()).getInnerType(new TypeMeta(null, oneOfType.type(), oneOfType.type()));
+				builder.possibleType(GraphQLTypeReference.typeRef(possible.getName()));
+			}
+
+			entityProcessor
+				.getCodeRegistry()
+				.typeResolver(
+					name,
+					env -> {
+						for (var oneOfType : oneOf.value()) {
+							if (oneOfType.type().isInstance(env.getObject())) {
+								return (GraphQLObjectType) entityProcessor
+									.getEntity(oneOfType.type())
+									.getInnerType(new TypeMeta(null, oneOfType.type(), oneOfType.type()));
+							}
+						}
+						throw new RuntimeException("OneOf " + name + " does not support type " + env.getObject().getClass().getSimpleName());
+					}
+				);
+
+			return builder.build();
+		}
+
+		@Override
+		protected void processFields(String typeName, Builder graphType, GraphQLInterfaceType.Builder interfaceBuilder) {
 		}
 	}
 

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -248,4 +248,5 @@ public abstract class TypeBuilder {
 			}
 		}
 	}
+
 }

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -294,8 +294,7 @@ public abstract class TypeBuilder {
 		}
 
 		@Override
-		protected void processFields(String typeName, Builder graphType, GraphQLInterfaceType.Builder interfaceBuilder) {
-		}
+		protected void processFields(String typeName, Builder graphType, GraphQLInterfaceType.Builder interfaceBuilder) {}
 	}
 
 }

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/annotations/GraphQLIgnore.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/annotations/GraphQLIgnore.java
@@ -18,5 +18,5 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Retention(RUNTIME)
-@Target({ ElementType.METHOD, ElementType.FIELD })
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.RECORD_COMPONENT, ElementType.CONSTRUCTOR })
 public @interface GraphQLIgnore {}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
@@ -1,0 +1,16 @@
+package com.phocassoftware.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+public class OneOfOutputTest {
+
+	@Test
+	public void testOneOfSealedInterfaceAsOutputType() {
+		assertDoesNotThrow(
+			() -> SchemaBuilder.build("com.phocassoftware.graphql.builder.oneofoutput"),
+			"@OneOf sealed interface used as output type should build schema without error"
+		);
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
@@ -12,16 +12,108 @@
 package com.phocassoftware.graphql.builder;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import graphql.GraphQL;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnionType;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class OneOfOutputTest {
 
+	private static GraphQLSchema schema() {
+		return SchemaBuilder.build("com.phocassoftware.graphql.builder.oneofoutput");
+	}
+
 	@Test
-	public void testOneOfSealedInterfaceAsOutputType() {
-		assertDoesNotThrow(
-			() -> SchemaBuilder.build("com.phocassoftware.graphql.builder.oneofoutput"),
-			"@OneOf sealed interface used as output type should build schema without error"
+	public void testSealedInterfaceAsOutputType() {
+		assertDoesNotThrow(OneOfOutputTest::schema, "Sealed interface used as output type should build schema without error");
+	}
+
+	@Test
+	public void testSealedInterfaceWithoutOneOfBecomesUnion() {
+		var type = schema().getType("Animal");
+		var union = assertInstanceOf(GraphQLUnionType.class, type, "A sealed interface with no fields should produce a union");
+		var members = union.getTypes().stream().map(t -> t.getName()).toList();
+		assertEquals(2, members.size());
+		assertTrue(members.contains("Cat"), () -> "expected Cat in " + members);
+		assertTrue(members.contains("Dog"), () -> "expected Dog in " + members);
+	}
+
+	@Test
+	public void testUnionResolvesConcreteTypeAtRuntime() {
+		var result = GraphQL
+			.newGraphQL(schema())
+			.build()
+			.execute("query { getAnimal { ... on Cat { name } ... on Dog { name } } }");
+
+		assertTrue(result.getErrors().isEmpty(), () -> result.getErrors().toString());
+		Map<String, Map<String, Object>> data = result.getData();
+		assertEquals(Map.of("name", "Mavi"), data.get("getAnimal"));
+	}
+
+	@Test
+	public void testOneOfInterfaceIsBothUnionOutputAndOneOfInput() {
+		var schema = schema();
+
+		var union = assertInstanceOf(GraphQLUnionType.class, schema.getType("Shape"), "Shape should be a union output");
+		var members = union.getTypes().stream().map(t -> t.getName()).toList();
+		assertTrue(members.contains("Circle") && members.contains("Square"), () -> "expected Circle and Square in " + members);
+
+		var input = assertInstanceOf(GraphQLInputObjectType.class, schema.getType("ShapeInput"), "Shape should also produce an input type");
+		var fields = input.getFieldDefinitions().stream().map(f -> f.getName()).toList();
+		assertTrue(fields.contains("circle") && fields.contains("square"), () -> "expected circle and square input fields in " + fields);
+		// @OneOf inputs are modelled as an input object whose variant fields are all optional.
+		input
+			.getFieldDefinitions()
+			.forEach(f -> assertInstanceOf(GraphQLInputObjectType.class, f.getType(), "variant fields should be nullable input objects"));
+	}
+
+	@Test
+	public void testOneOfInterfaceRoundTripsThroughInputAndOutput() {
+		var result = GraphQL
+			.newGraphQL(schema())
+			.build()
+			.execute("mutation { putShape(shape: { circle: { radius: 2.0 } }) { ... on Circle { radius } ... on Square { side } } }");
+
+		assertTrue(result.getErrors().isEmpty(), () -> result.getErrors().toString());
+		Map<String, Map<String, Object>> data = result.getData();
+		assertEquals(Map.of("radius", 2.0), data.get("putShape"));
+	}
+
+	@Test
+	public void testNonSealedInterfaceWithEntityImplementationsBecomesUnion() {
+		var schema = SchemaBuilder.build("com.phocassoftware.graphql.builder.nonsealedoutput");
+
+		var union = assertInstanceOf(
+			GraphQLUnionType.class,
+			schema.getType("Thing"),
+			"A non-sealed interface should still produce a union via its @Entity implementations"
+		);
+		var members = union.getTypes().stream().map(t -> t.getName()).toList();
+		assertEquals(2, members.size());
+		assertTrue(members.contains("A") && members.contains("B"), () -> "expected A and B in " + members);
+	}
+
+	@Test
+	public void testInterfaceWithNoDiscoverableImplementationsFailsWithClearMessage() {
+		var error = assertThrows(
+			RuntimeException.class,
+			() -> SchemaBuilder.build("com.phocassoftware.graphql.builder.nomembersoutput")
+		);
+
+		var message = new StringBuilder();
+		for (Throwable t = error; t != null; t = t.getCause()) {
+			message.append(t.getMessage()).append('\n');
+		}
+		assertTrue(
+			message.toString().contains("@Entity"),
+			() -> "expected a message explaining how to provide union members, got: " + message
 		);
 	}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
@@ -100,6 +100,31 @@ public class OneOfOutputTest {
 		assertTrue(members.contains("A") && members.contains("B"), () -> "expected A and B in " + members);
 	}
 
+	// --- comment 1: only field-less interfaces become unions ---
+
+	interface Marker {}
+
+	interface WithGetter {
+		String getName();
+	}
+
+	interface WithStaticOnly {
+		static int answer() {
+			return 42;
+		}
+	}
+
+	@Test
+	public void testOnlyFieldLessInterfacesAreTreatedAsUnions() {
+		// field-less interfaces (no getters) are represented as unions
+		assertEquals(false, EntityUtil.hasFields(Marker.class));
+		assertEquals(false, EntityUtil.hasFields(WithStaticOnly.class));
+		assertEquals(false, EntityUtil.hasFields(com.phocassoftware.graphql.builder.oneofoutput.Animal.class));
+		assertEquals(false, EntityUtil.hasFields(com.phocassoftware.graphql.builder.oneofoutput.Shape.class));
+		// an interface that declares a getter has fields and must not be turned into a union
+		assertEquals(true, EntityUtil.hasFields(WithGetter.class));
+	}
+
 	@Test
 	public void testInterfaceWithNoDiscoverableImplementationsFailsWithClearMessage() {
 		var error = assertThrows(

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/OneOfOutputTest.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
@@ -1,0 +1,76 @@
+package com.phocassoftware.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import graphql.ExecutionInput;
+import graphql.GraphQL;
+import graphql.schema.Coercing;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ScalarRegistrationTest {
+
+	public static class ZoneIdCoercing implements Coercing<ZoneId, ZoneId> {
+
+		@Override
+		public ZoneId serialize(Object dataFetcherResult) {
+			if (dataFetcherResult instanceof ZoneId z) return z;
+			return ZoneId.of(dataFetcherResult.toString());
+		}
+
+		@Override
+		public ZoneId parseValue(Object input) {
+			if (input instanceof ZoneId z) return z;
+			return ZoneId.of(input.toString());
+		}
+
+		@Override
+		public ZoneId parseLiteral(Object input) {
+			return ZoneId.of(input.toString());
+		}
+	}
+
+	private static final GraphQLScalarType ZONE_ID_SCALAR = new GraphQLScalarType.Builder()
+		.name("ZoneId")
+		.coercing(new ZoneIdCoercing())
+		.build();
+
+	private static final GraphQL graphQL = GraphQL
+		.newGraphQL(
+			SchemaBuilder
+				.builder()
+				.classpath("com.phocassoftware.graphql.builder.scalartest")
+				.scalar(ZONE_ID_SCALAR)
+				.build()
+				.build()
+		)
+		.build();
+
+	@Test
+	public void schemaBuildsWithCustomScalarInOneOfUnion() {
+		assertNotNull(graphQL);
+	}
+
+	@Test
+	public void queryReturnsCustomScalarField() {
+		var result = graphQL.execute(
+			ExecutionInput.newExecutionInput()
+				.query("query { widgets { ... on TimedWidget { name timeZone } ... on SimpleWidget { name } } }")
+				.build()
+		);
+
+		assertTrue(result.getErrors().isEmpty(), "Expected no errors but got: " + result.getErrors());
+		Map<String, List<Map<String, Object>>> data = result.getData();
+		var widgets = data.get("widgets");
+		assertEquals(2, widgets.size());
+
+		assertEquals("hello", widgets.get(0).get("name"));
+		assertEquals("world", widgets.get(1).get("name"));
+		assertNotNull(widgets.get(1).get("timeZone"));
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ScalarRegistrationTest.java
@@ -58,11 +58,13 @@ public class ScalarRegistrationTest {
 
 	@Test
 	public void queryReturnsCustomScalarField() {
-		var result = graphQL.execute(
-			ExecutionInput.newExecutionInput()
-				.query("query { widgets { ... on TimedWidget { name timeZone } ... on SimpleWidget { name } } }")
-				.build()
-		);
+		var result = graphQL
+			.execute(
+				ExecutionInput
+					.newExecutionInput()
+					.query("query { widgets { ... on TimedWidget { name timeZone } ... on SimpleWidget { name } } }")
+					.build()
+			);
 
 		assertTrue(result.getErrors().isEmpty(), "Expected no errors but got: " + result.getErrors());
 		Map<String, List<Map<String, Object>>> data = result.getData();

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nomembersoutput/Mystery.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nomembersoutput/Mystery.java
@@ -9,25 +9,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.phocassoftware.graphql.builder.oneofoutput;
+package com.phocassoftware.graphql.builder.nomembersoutput;
 
-import com.phocassoftware.graphql.builder.annotations.Mutation;
-import com.phocassoftware.graphql.builder.annotations.Query;
+// A non-sealed interface whose implementation is not annotated with @Entity, so no union members can
+// be discovered. The schema build must fail with a clear, actionable message.
+public interface Mystery {
 
-public class Queries {
-
-	@Query
-	public static Shape getShape() {
-		return new Shape.Circle(5.0);
-	}
-
-	@Mutation
-	public static Shape putShape(Shape shape) {
-		return shape;
-	}
-
-	@Query
-	public static Animal getAnimal() {
-		return new Animal.Cat("Mavi");
-	}
+	record Hidden(String name) implements Mystery {}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nomembersoutput/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nomembersoutput/Queries.java
@@ -9,24 +9,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.phocassoftware.graphql.builder.scalartest;
+package com.phocassoftware.graphql.builder.nomembersoutput;
 
-import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;
-import com.phocassoftware.graphql.builder.annotations.OneOf;
 import com.phocassoftware.graphql.builder.annotations.Query;
 
-import java.time.ZoneId;
-import java.util.List;
-
-@OneOf({
-	@OneOf.Type(name = "timedWidget", type = TimedWidget.class),
-	@OneOf.Type(name = "simpleWidget", type = SimpleWidget.class),
-})
-@GraphQLDescription("A widget.")
-public sealed interface Widget permits TimedWidget, SimpleWidget {
+public class Queries {
 
 	@Query
-	static List<Widget> widgets() {
-		return List.of(new SimpleWidget("hello"), new TimedWidget("world", ZoneId.of("UTC")));
+	public static Mystery getMystery() {
+		return new Mystery.Hidden("x");
 	}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nonsealedoutput/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nonsealedoutput/Queries.java
@@ -9,24 +9,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.phocassoftware.graphql.builder.scalartest;
+package com.phocassoftware.graphql.builder.nonsealedoutput;
 
-import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;
-import com.phocassoftware.graphql.builder.annotations.OneOf;
 import com.phocassoftware.graphql.builder.annotations.Query;
 
-import java.time.ZoneId;
-import java.util.List;
-
-@OneOf({
-	@OneOf.Type(name = "timedWidget", type = TimedWidget.class),
-	@OneOf.Type(name = "simpleWidget", type = SimpleWidget.class),
-})
-@GraphQLDescription("A widget.")
-public sealed interface Widget permits TimedWidget, SimpleWidget {
+public class Queries {
 
 	@Query
-	static List<Widget> widgets() {
-		return List.of(new SimpleWidget("hello"), new TimedWidget("world", ZoneId.of("UTC")));
+	public static Thing getThing() {
+		return new Thing.A("x");
 	}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nonsealedoutput/Thing.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nonsealedoutput/Thing.java
@@ -9,25 +9,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.phocassoftware.graphql.builder.oneofoutput;
+package com.phocassoftware.graphql.builder.nonsealedoutput;
 
-import com.phocassoftware.graphql.builder.annotations.Mutation;
-import com.phocassoftware.graphql.builder.annotations.Query;
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
 
-public class Queries {
+// A non-sealed, field-less interface used as an output type. Its @Entity implementations are
+// discovered during the scan, so it still produces a union.
+public interface Thing {
 
-	@Query
-	public static Shape getShape() {
-		return new Shape.Circle(5.0);
-	}
+	@Entity(SchemaOption.TYPE)
+	record A(String name) implements Thing {}
 
-	@Mutation
-	public static Shape putShape(Shape shape) {
-		return shape;
-	}
-
-	@Query
-	public static Animal getAnimal() {
-		return new Animal.Cat("Mavi");
-	}
+	@Entity(SchemaOption.TYPE)
+	record B(String name) implements Thing {}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Animal.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Animal.java
@@ -11,23 +11,15 @@
  */
 package com.phocassoftware.graphql.builder.oneofoutput;
 
-import com.phocassoftware.graphql.builder.annotations.Mutation;
-import com.phocassoftware.graphql.builder.annotations.Query;
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
 
-public class Queries {
+// Output-only sealed interface: produces a union without the @OneOf annotation.
+public sealed interface Animal {
 
-	@Query
-	public static Shape getShape() {
-		return new Shape.Circle(5.0);
-	}
+	@Entity(SchemaOption.TYPE)
+	record Cat(String name) implements Animal {}
 
-	@Mutation
-	public static Shape putShape(Shape shape) {
-		return shape;
-	}
-
-	@Query
-	public static Animal getAnimal() {
-		return new Animal.Cat("Mavi");
-	}
+	@Entity(SchemaOption.TYPE)
+	record Dog(String name) implements Animal {}
 }

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Queries.java
@@ -1,0 +1,17 @@
+package com.phocassoftware.graphql.builder.oneofoutput;
+
+import com.phocassoftware.graphql.builder.annotations.Mutation;
+import com.phocassoftware.graphql.builder.annotations.Query;
+
+public class Queries {
+
+	@Query
+	public static Shape getShape() {
+		return new Shape.Circle(5.0);
+	}
+
+	@Mutation
+	public static Shape putShape(Shape shape) {
+		return shape;
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Queries.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder.oneofoutput;
 
 import com.phocassoftware.graphql.builder.annotations.Mutation;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Shape.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Shape.java
@@ -1,0 +1,18 @@
+package com.phocassoftware.graphql.builder.oneofoutput;
+
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.OneOf;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
+
+@OneOf({
+	@OneOf.Type(type = Shape.Circle.class, name = "circle"),
+	@OneOf.Type(type = Shape.Square.class, name = "square"),
+})
+public sealed interface Shape {
+
+	@Entity(SchemaOption.BOTH)
+	record Circle(double radius) implements Shape {}
+
+	@Entity(SchemaOption.BOTH)
+	record Square(double side) implements Shape {}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Shape.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/oneofoutput/Shape.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder.oneofoutput;
 
 import com.phocassoftware.graphql.builder.annotations.Entity;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/SimpleWidget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/SimpleWidget.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder.scalartest;
 
 public record SimpleWidget(String name) implements Widget {}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/SimpleWidget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/SimpleWidget.java
@@ -1,0 +1,3 @@
+package com.phocassoftware.graphql.builder.scalartest;
+
+public record SimpleWidget(String name) implements Widget {}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/TimedWidget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/TimedWidget.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder.scalartest;
 
 import java.time.ZoneId;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/TimedWidget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/TimedWidget.java
@@ -1,0 +1,5 @@
+package com.phocassoftware.graphql.builder.scalartest;
+
+import java.time.ZoneId;
+
+public record TimedWidget(String name, ZoneId timeZone) implements Widget {}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/Widget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/Widget.java
@@ -1,3 +1,14 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.phocassoftware.graphql.builder.scalartest;
 
 import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/Widget.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/scalartest/Widget.java
@@ -1,0 +1,20 @@
+package com.phocassoftware.graphql.builder.scalartest;
+
+import com.phocassoftware.graphql.builder.annotations.GraphQLDescription;
+import com.phocassoftware.graphql.builder.annotations.OneOf;
+import com.phocassoftware.graphql.builder.annotations.Query;
+
+import java.util.List;
+
+@OneOf({
+	@OneOf.Type(name = "timedWidget", type = TimedWidget.class),
+	@OneOf.Type(name = "simpleWidget", type = SimpleWidget.class),
+})
+@GraphQLDescription("A widget.")
+public sealed interface Widget permits TimedWidget, SimpleWidget {
+
+	@Query
+	static List<Widget> widgets() {
+		return List.of(new SimpleWidget("hello"), new TimedWidget("world", java.time.ZoneId.of("UTC")));
+	}
+}


### PR DESCRIPTION
## Problem

An interface with no fields fails when used as a GraphQL **output** type: the builder generates a `GraphQLInterfaceType`, which requires at least one field. (Interface methods aren't treated as getters, so such an interface always has zero fields.)

## Change

Represent an interface used as an output type as a `GraphQLUnionType` instead. Detection is based purely on the type being a **field-less interface**.

- **`TypeBuilder.InterfaceUnion`** builds a `GraphQLUnionType` for an interface, registering a runtime type resolver that maps an instance to its concrete object type.
- **Union members are discovered from the scan**, via `EntityProcessor.getImplementations(...)`:
  - sealed interfaces → their permitted subclasses, and/or
  - any `@Entity`-annotated implementation found during the package scan.
  
  This means **non-sealed interfaces are supported too**, as long as their implementations are annotated with `@Entity`. The scanned `@Entity` set is threaded into the processor from `SchemaBuilder`.
- `@OneOf` is **still honored for the input side** — a sealed/`@OneOf` interface used as both input and output produces a `oneOf`-style input object *and* a union output.
- If no implementations can be discovered for an interface, the build fails with an actionable message (make it sealed, or annotate implementations with `@Entity`) rather than a cryptic `NullPointerException`.

### Also included
- Expand `@GraphQLIgnore` target to support `RECORD_COMPONENT` and `CONSTRUCTOR`.
- Fix custom scalar registration (e.g. `ZoneId`) where `addScalars` resolved the wrong `parseValue` overload, returning `Object` instead of the concrete type.
- Guard JDK types (`java.*` / `javax.*` / `jakarta.*`) so they resolve as scalars rather than being processed as entities.

## Tests
- Sealed `@OneOf` interface used as **both** input and output (union output + `oneOf` input + runtime round-trip).
- Sealed interface, **no** `@OneOf`, as output → union (schema shape + runtime resolution).
- **Non-sealed** interface with `@Entity` implementations → union.
- Interface with no discoverable implementations → build fails with a clear message.
- Scalar registration coverage.
