### PR TITLE
DS-807 inherit graphql ignore

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
@@ -12,6 +12,7 @@
 package com.phocassoftware.graphql.builder;
 
 import com.phocassoftware.graphql.builder.annotations.Context;
+import com.phocassoftware.graphql.builder.annotations.GraphQLField;
 import com.phocassoftware.graphql.builder.annotations.GraphQLIgnore;
 import com.phocassoftware.graphql.builder.annotations.GraphQLName;
 import com.phocassoftware.graphql.builder.annotations.InputIgnore;
@@ -82,7 +83,9 @@ class EntityUtil {
 		if (method.getDeclaringClass().equals(Object.class)) {
 			return Optional.empty();
 		}
-		if (method.isAnnotationPresent(GraphQLIgnore.class)) {
+		// @GraphQLField overrules an inherited @GraphQLIgnore.
+		boolean forced = isForcedField(method);
+		if (!forced && isAnnotatedInHierarchy(method, GraphQLIgnore.class)) {
 			return Optional.empty();
 		}
 		// will also be on implementing class
@@ -99,7 +102,7 @@ class EntityUtil {
 				name = method.getName().substring("is".length(), "is".length() + 1).toLowerCase() + method.getName().substring("is".length() + 1);
 			}
 
-			if (fieldSpecifiesIgnore(method, name)) {
+			if (!forced && fieldSpecifiesIgnore(method, name)) {
 				return Optional.empty();
 			}
 
@@ -141,7 +144,9 @@ class EntityUtil {
 		if (method.getDeclaringClass().equals(Object.class)) {
 			return Optional.empty();
 		}
-		if (method.isAnnotationPresent(GraphQLIgnore.class)) {
+		// @GraphQLField overrules an inherited @GraphQLIgnore.
+		boolean forced = isForcedField(method);
+		if (!forced && isAnnotatedInHierarchy(method, GraphQLIgnore.class)) {
 			return Optional.empty();
 		}
 		// will also be on implementing class
@@ -154,7 +159,7 @@ class EntityUtil {
 			if (method.getParameterCount() == 1 && !method.isAnnotationPresent(InputIgnore.class)) {
 				String name = method.getName().substring("set".length(), "set".length() + 1).toLowerCase() + method.getName().substring("set".length() + 1);
 
-				if (fieldSpecifiesIgnore(method, name)) {
+				if (!forced && fieldSpecifiesIgnore(method, name)) {
 					return Optional.empty();
 				}
 
@@ -162,6 +167,50 @@ class EntityUtil {
 			}
 		}
 		return Optional.empty();
+	}
+
+	/**
+	 * Returns whether {@code method}, or any declaration it overrides in a superclass or interface, carries the
+	 * given annotation. Method annotations are not inherited by the JVM, so this walks the type hierarchy to
+	 * give {@link GraphQLIgnore} (and its {@link GraphQLField} override) effect across implementations.
+	 */
+	static boolean isAnnotatedInHierarchy(Method method, Class<? extends Annotation> annotation) {
+		return declaredWithAnnotation(method.getDeclaringClass(), method.getName(), method.getParameterTypes(), annotation);
+	}
+
+	/** Whether {@code method} should be hidden from the schema because of an (inherited) {@link GraphQLIgnore}. */
+	static boolean isIgnored(Method method) {
+		if (isForcedField(method)) {
+			return false;
+		}
+		return isAnnotatedInHierarchy(method, GraphQLIgnore.class);
+	}
+
+	/** Whether {@code method} carries an (inherited) {@link GraphQLField}, which overrules any {@link GraphQLIgnore}. */
+	static boolean isForcedField(Method method) {
+		return isAnnotatedInHierarchy(method, GraphQLField.class);
+	}
+
+	private static boolean declaredWithAnnotation(Class<?> type, String name, Class<?>[] parameterTypes, Class<? extends Annotation> annotation) {
+		if (type == null) {
+			return false;
+		}
+		try {
+			if (type.getDeclaredMethod(name, parameterTypes).isAnnotationPresent(annotation)) {
+				return true;
+			}
+		} catch (NoSuchMethodException e) {
+			// not declared at this level; keep walking up
+		}
+		if (declaredWithAnnotation(type.getSuperclass(), name, parameterTypes, annotation)) {
+			return true;
+		}
+		for (var parent : type.getInterfaces()) {
+			if (declaredWithAnnotation(parent, name, parameterTypes, annotation)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	static boolean fieldSpecifiesIgnore(Method method, String name) {

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/TypeBuilder.java
@@ -213,7 +213,7 @@ public abstract class TypeBuilder {
 				.filter(method -> !method.isSynthetic())
 				.filter(method -> !method.getDeclaringClass().equals(Object.class))
 				.filter(method -> !isObjectContractMethod(method))
-				.filter(method -> !method.isAnnotationPresent(GraphQLIgnore.class))
+				.filter(method -> !EntityUtil.isIgnored(method))
 				.filter(method -> !Modifier.isStatic(method.getModifiers()))
 				.filter(method -> !method.getReturnType().equals(void.class))
 				.filter(method -> {
@@ -225,7 +225,7 @@ public abstract class TypeBuilder {
 				})
 				.forEach(method -> {
 					var field = fieldsByName.get(method.getName());
-					if (field != null && field.isAnnotationPresent(GraphQLIgnore.class)) {
+					if (field != null && field.isAnnotationPresent(GraphQLIgnore.class) && !EntityUtil.isForcedField(method)) {
 						return;
 					}
 					var name = field != null

--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/annotations/GraphQLField.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/annotations/GraphQLField.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.annotations;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Forces a field to be exposed in the schema, overruling any {@link GraphQLIgnore} inherited from a parent
+ * type (for example an interface method or a superclass getter).
+ */
+@Retention(RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.RECORD_COMPONENT })
+public @interface GraphQLField {}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/IgnoreInheritanceTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/IgnoreInheritanceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class IgnoreInheritanceTest {
+
+	private static final GraphQL SCHEMA = GraphQL
+		.newGraphQL(SchemaBuilder.build("com.phocassoftware.graphql.builder.ignoreinheritance"))
+		.build();
+
+	private static Set<String> fieldsOf(String typeName) {
+		ExecutionResult result = SCHEMA.execute("{ __type(name: \"" + typeName + "\") { fields { name } } }");
+		assertTrue(result.getErrors().isEmpty(), () -> result.getErrors().toString());
+		Map<String, Map<String, List<Map<String, String>>>> data = result.getData();
+		return data.get("__type").get("fields").stream().map(f -> f.get("name")).collect(Collectors.toSet());
+	}
+
+	@Test
+	public void testInterfaceIgnoreIsInheritedByImplementation() {
+		assertEquals(Set.of("name"), fieldsOf("Dog"), "secret should be hidden because the interface method is @GraphQLIgnore");
+	}
+
+	@Test
+	public void testGraphQLFieldOverrulesInheritedIgnoreOnRecord() {
+		assertEquals(Set.of("name", "secret"), fieldsOf("Cat"), "@GraphQLField should re-expose the inherited-ignored secret");
+	}
+
+	@Test
+	public void testSuperclassIgnoreIsInheritedBySubclass() {
+		assertEquals(Set.of("shared", "model"), fieldsOf("Car"), "internal should be hidden because the superclass getter is @GraphQLIgnore");
+	}
+
+	@Test
+	public void testGraphQLFieldOverrulesInheritedIgnoreOnClass() {
+		assertEquals(Set.of("shared", "model", "internal"), fieldsOf("Bike"), "@GraphQLField should re-expose the inherited-ignored internal");
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Animal.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Animal.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.ignoreinheritance;
+
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.GraphQLField;
+import com.phocassoftware.graphql.builder.annotations.GraphQLIgnore;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
+
+public sealed interface Animal {
+
+	String name();
+
+	@GraphQLIgnore
+	String secret();
+
+	// Inherits the @GraphQLIgnore on secret() from the interface, so secret is hidden.
+	@Entity(SchemaOption.TYPE)
+	record Dog(String name, String secret) implements Animal {}
+
+	// Overrules the inherited @GraphQLIgnore with @GraphQLField, so secret is exposed.
+	@Entity(SchemaOption.TYPE)
+	record Cat(String name, String secret) implements Animal {
+
+		@GraphQLField
+		@Override
+		public String secret() {
+			return secret;
+		}
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Base.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Base.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.ignoreinheritance;
+
+import com.phocassoftware.graphql.builder.annotations.GraphQLIgnore;
+
+public abstract class Base {
+
+	@GraphQLIgnore
+	public String getInternal() {
+		return "internal";
+	}
+
+	public String getShared() {
+		return "shared";
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Bike.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Bike.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.ignoreinheritance;
+
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.GraphQLField;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
+
+// Overrules the inherited @GraphQLIgnore on getInternal() with @GraphQLField, so internal is exposed.
+@Entity(SchemaOption.TYPE)
+public class Bike extends Base {
+
+	@GraphQLField
+	@Override
+	public String getInternal() {
+		return "shown";
+	}
+
+	public String getModel() {
+		return "model";
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Car.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Car.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.ignoreinheritance;
+
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
+
+// Inherits getInternal() with its @GraphQLIgnore from Base, so internal is hidden.
+@Entity(SchemaOption.TYPE)
+public class Car extends Base {
+
+	public String getModel() {
+		return "model";
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ignoreinheritance/Queries.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.ignoreinheritance;
+
+import com.phocassoftware.graphql.builder.annotations.Query;
+import java.util.List;
+
+public class Queries {
+
+	@Query
+	public static List<Animal> animals() {
+		return List.of(new Animal.Dog("rex", "bone"), new Animal.Cat("mavi", "fish"));
+	}
+
+	@Query
+	public static Car car() {
+		return new Car();
+	}
+
+	@Query
+	public static Bike bike() {
+		return new Bike();
+	}
+}


### PR DESCRIPTION
## Inherit `@GraphQLIgnore` across implementations

`@GraphQLIgnore` placed on a parent type (an interface method or a superclass getter) is now inherited by the concrete implementations, so the field is hidden everywhere rather than re-appearing on each subtype. Java does not inherit method annotations, so the builder walks the type hierarchy to apply the ignore consistently.

A new `@GraphQLField` annotation lets an implementation overrule an inherited `@GraphQLIgnore` and force the field back into the schema.

### Type hierarchies under test

`[I]` = `@GraphQLIgnore`, `[F]` = `@GraphQLField` (overrides the inherited ignore)

```
  Animal (interface)            Base (abstract class)
    name()                        getShared()
    secret() [I]                  getInternal() [I]
     |                             |
     +-- Dog   (secret hidden)     +-- Car  (internal hidden)
     +-- Cat   secret() [F]        +-- Bike getInternal() [F]
               (secret shown)           (internal shown)
```
