### PR TITLE
DS-807: flatten nested sealed interfaces into union members

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
@@ -68,7 +68,17 @@ public class EntityProcessor {
 		var permitted = interfaceType.getPermittedSubclasses();
 		if (permitted != null) {
 			for (var subType : permitted) {
-				implementations.add(subType);
+				// A union member must be a concrete object type. A permitted subtype that is itself an
+				// interface or abstract class (a nested sealed hierarchy) is flattened to its concrete leaves.
+				if (subType.isInterface() || Modifier.isAbstract(subType.getModifiers())) {
+					for (var leaf : getImplementations(subType)) {
+						if (!implementations.contains(leaf)) {
+							implementations.add(leaf);
+						}
+					}
+				} else if (!implementations.contains(subType)) {
+					implementations.add(subType);
+				}
 			}
 		}
 		for (var candidate : entityTypes) {

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/NestedUnionOutputTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/NestedUnionOutputTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnionType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class NestedUnionOutputTest {
+
+	private static GraphQLSchema schema() {
+		return SchemaBuilder.build("com.phocassoftware.graphql.builder.nestedunionoutput");
+	}
+
+	@Test
+	public void nestedSealedInterfaceFlattensToConcreteLeaves() {
+		var union = assertInstanceOf(GraphQLUnionType.class, schema().getType("Vehicle"), "field-less sealed interface should be a union");
+		var members = union.getTypes().stream().map(t -> t.getName()).toList();
+
+		// The nested LandVehicle interface must be flattened to its concrete leaves, not included as a member.
+		assertFalse(members.contains("LandVehicle"), () -> "union must not contain the nested interface, got " + members);
+		assertEquals(3, members.size(), () -> "expected three concrete members, got " + members);
+		assertTrue(members.containsAll(java.util.List.of("Car", "Truck", "Boat")), () -> "expected Car, Truck, Boat in " + members);
+	}
+
+	@Test
+	public void resolvesNestedLeafAtRuntime() {
+		var result = GraphQL
+			.newGraphQL(schema())
+			.build()
+			.execute("query { getVehicle { ... on Car { name } ... on Truck { name } ... on Boat { name } } }");
+
+		assertTrue(result.getErrors().isEmpty(), () -> result.getErrors().toString());
+		Map<String, Map<String, Object>> data = result.getData();
+		assertEquals(Map.of("name", "Beetle"), data.get("getVehicle"));
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nestedunionoutput/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nestedunionoutput/Queries.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.nestedunionoutput;
+
+import com.phocassoftware.graphql.builder.annotations.Query;
+
+public class Queries {
+
+	@Query
+	public static Vehicle getVehicle() {
+		return new Vehicle.Car("Beetle");
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nestedunionoutput/Vehicle.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/nestedunionoutput/Vehicle.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.nestedunionoutput;
+
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.SchemaOption;
+
+// Field-less sealed interface whose permits list contains a nested sealed interface (LandVehicle) as well
+// as a concrete type (Boat). The generated union must flatten LandVehicle to its concrete leaves.
+public sealed interface Vehicle permits Vehicle.LandVehicle, Vehicle.Boat {
+
+	sealed interface LandVehicle extends Vehicle permits Car, Truck {}
+
+	@Entity(SchemaOption.TYPE)
+	record Car(String name) implements LandVehicle {}
+
+	@Entity(SchemaOption.TYPE)
+	record Truck(String name) implements LandVehicle {}
+
+	@Entity(SchemaOption.TYPE)
+	record Boat(String name) implements Vehicle {}
+}


### PR DESCRIPTION
## What

`InterfaceUnion.getImplementations()` built a union's members from `getPermittedSubclasses()`, adding each permitted subtype verbatim. When a field-less sealed interface permits **another sealed interface** (a nested hierarchy), the nested interface was added as a union member.

This change recurses into permitted subtypes that are themselves interfaces or abstract classes, collecting their concrete leaves instead of the interface itself.

## Why

The GraphQL spec requires union members to all be concrete Object base types — *"Scalar, Interface and Union types must not be member types of a Union."* The previous behaviour produced an invalid schema for nested sealed hierarchies:

```
The member types of a Union type must all be Object base types.
member type "CalculatedSourceVariable" in Union "CalculatedVariable" is invalid.
```

`CalculatedVariable` is a field-less sealed interface that permits `CalculatedSourceVariable`, which is itself a field-less sealed interface. A field-less interface cannot be a GraphQL interface (must define ≥1 field), so it is represented as a union — and a union cannot contain another union/interface as a member. Flattening to concrete leaves is the only spec-valid representation.

## Test

`NestedUnionOutputTest` covers a sealed interface whose permits list mixes a nested sealed interface with a concrete type, asserting the union flattens to concrete leaves (no nested interface member) and resolves the correct concrete type at runtime.