### PR TITLE
DS-807: bind Object-returning coercings to Object.class

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityProcessor.java
@@ -110,7 +110,7 @@ public class EntityProcessor {
 			var coercing = scalar.getCoercing();
 			var type = coercing.getClass();
 			Class<?> returnType = resolveScalarType(type);
-			if (returnType != null && !returnType.equals(Object.class)) {
+			if (returnType != null) {
 				if (returnType.equals(Long.class)) {
 					put(Long.TYPE, new ScalarEntity(scalar));
 				} else if (returnType.equals(Byte.class)) {
@@ -138,7 +138,9 @@ public class EntityProcessor {
 				best = returnType;
 			}
 		}
-		return best;
+		// A coercing whose parseValue only ever yields Object (e.g. the JSON scalar) genuinely targets
+		// Object, so bind it to Object.class rather than leaving it unmapped.
+		return best != null ? best : Object.class;
 	}
 
 	private void put(Class<?> type, ScalarEntity entity) {

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ObjectScalarTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ObjectScalarTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.scalars.ExtendedScalars;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ObjectScalarTest {
+
+	@Test
+	public void objectFieldServedByRegisteredObjectScalar() {
+		// The JSON scalar's coercing only ever yields Object. It must be bound to Object.class so that
+		// an Object-typed field is serialised through it, rather than degrading to the String scalar's toString.
+		Map<String, Object> data = execute("{ getPayload }").getData();
+		assertEquals(Map.of("id", "some value"), data.get("getPayload"));
+	}
+
+	private ExecutionResult execute(String query) {
+		GraphQL schema = GraphQL
+			.newGraphQL(
+				SchemaBuilder.builder().classpath("com.phocassoftware.graphql.builder.objectscalar").scalar(ExtendedScalars.Json).build().build()
+			)
+			.build();
+		ExecutionResult result = schema.execute(ExecutionInput.newExecutionInput().query(query).build());
+		if (!result.getErrors().isEmpty()) {
+			throw new RuntimeException(result.getErrors().toString());
+		}
+		return result;
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/objectscalar/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/objectscalar/Queries.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.objectscalar;
+
+import com.phocassoftware.graphql.builder.annotations.Query;
+import java.util.Map;
+
+public class Queries {
+
+	// Object return type, served by the registered Object-targeting scalar (the JSON scalar).
+	@Query
+	public static Object getPayload() {
+		return Map.of("id", "some value");
+	}
+}


### PR DESCRIPTION
## What

`resolveScalarType` skips every `parseValue` that returns `Object`. A coercing whose `parseValue` only ever yields `Object` (e.g. the JSON scalar, `ObjectScalar$1`) therefore resolved to `null` and `addScalars` never mapped it to a Java type. Fields typed as `Object` then fell back to the default `GraphQLString` scalar and were serialised via `toString`.

This restores the prior behaviour: fall back to `Object.class` when no more specific `parseValue` return type is found, and let `addScalars` register that mapping.

## Why

Consumers register an `Object`-targeting scalar (e.g. `ExtendedScalars.Json`) to serialise `Object`-typed fields as JSON. Without an `Object` mapping those fields silently degrade to `toString`, corrupting query output. Coercings that expose a concrete `parseValue` (`Instant`, `Duration`, `SchemaField`, `Long`, …) still resolve to that concrete type and are unchanged.