### PR TITLE
Fix Object-typed arguments being dropped from the schema

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/EntityUtil.java
@@ -243,7 +243,7 @@ class EntityUtil {
 				return true;
 			}
 		}
-		return (class1.isAssignableFrom(GraphQLContext.class) || class1.isAssignableFrom(DataFetchingEnvironment.class) || class1
+		return (GraphQLContext.class.isAssignableFrom(class1) || DataFetchingEnvironment.class.isAssignableFrom(class1) || class1
 			.isAnnotationPresent(Context.class));
 	}
 

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ObjectScalarTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/ObjectScalarTest.java
@@ -12,11 +12,14 @@
 package com.phocassoftware.graphql.builder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.scalars.ExtendedScalars;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLTypeUtil;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -30,12 +33,26 @@ public class ObjectScalarTest {
 		assertEquals(Map.of("id", "some value"), data.get("getPayload"));
 	}
 
+	@Test
+	public void objectParameterAppearsAsArgumentOnGeneratedField() {
+		var field = buildSchema().getQueryType().getField("echoPayload");
+
+		assertNotNull(field.getArgument("settings"), "Object-typed 'settings' argument is missing from the generated field");
+		assertEquals("JSON", GraphQLTypeUtil.simplePrint(GraphQLTypeUtil.unwrapNonNull(field.getArgument("settings").getType())));
+	}
+
+	@Test
+	public void objectParameterIsRoundTrippedThroughTheField() {
+		Map<String, Object> data = execute("{ echoPayload(settings: {id: \"some value\"}) }").getData();
+		assertEquals(Map.of("id", "some value"), data.get("echoPayload"));
+	}
+
+	private GraphQLSchema buildSchema() {
+		return SchemaBuilder.builder().classpath("com.phocassoftware.graphql.builder.objectscalar").scalar(ExtendedScalars.Json).build().build();
+	}
+
 	private ExecutionResult execute(String query) {
-		GraphQL schema = GraphQL
-			.newGraphQL(
-				SchemaBuilder.builder().classpath("com.phocassoftware.graphql.builder.objectscalar").scalar(ExtendedScalars.Json).build().build()
-			)
-			.build();
+		GraphQL schema = GraphQL.newGraphQL(buildSchema()).build();
 		ExecutionResult result = schema.execute(ExecutionInput.newExecutionInput().query(query).build());
 		if (!result.getErrors().isEmpty()) {
 			throw new RuntimeException(result.getErrors().toString());

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/objectscalar/Queries.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/objectscalar/Queries.java
@@ -21,4 +21,9 @@ public class Queries {
 	public static Object getPayload() {
 		return Map.of("id", "some value");
 	}
+
+	@Query
+	public static Object echoPayload(Object settings) {
+		return settings;
+	}
 }


### PR DESCRIPTION
## Problem

Any endpoint parameter typed as bare `Object` was silently dropped from the generated GraphQL schema. For example:

```java
@Mutation
public static String addWidgetToDashboard(ApiContext context, Object settings, @Id String favouriteId, @Id String dashboardId, int databaseId) { ... }
```

generated a field with no `settings` argument at all.
