### PR TITLE
add support for cascading link deletion

### DIFF
--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/Database.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/Database.java
@@ -21,6 +21,7 @@ import com.phocassoftware.graphql.database.manager.util.TableCoreUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -220,10 +221,29 @@ public class Database {
 	}
 
 	public <T extends Table> CompletableFuture<T> delete(T entity, boolean deleteLinks) {
+		return delete(entity, deleteLinks ? DeleteOptions.unlinkOnly() : DeleteOptions.rejectIfLinked());
+	}
+
+	public <T extends Table> CompletableFuture<T> delete(T entity, DeleteOptions options) {
+		return switch (Objects.requireNonNull(options, "options").mode()) {
+			case REJECT_IF_LINKED -> delete(entity, false, false);
+			case UNLINK_ONLY -> delete(entity, true, false);
+			case CASCADE -> delete(entity, true, true, options.includedTypes());
+		};
+	}
+
+	private <T extends Table> CompletableFuture<T> delete(T entity, boolean deleteLinks, boolean cascade) {
+		return delete(entity, deleteLinks, cascade, Set.of());
+	}
+
+	private <T extends Table> CompletableFuture<T> delete(T entity, boolean deleteLinks, boolean cascade, Set<Class<? extends Table>> includedTypes) {
 		if (!deleteLinks) {
 			if (!TableAccess.getTableLinks(entity).isEmpty()) {
 				throw new RuntimeException("deleting would leave dangling links");
 			}
+		}
+		if (cascade) {
+			return deleteCascade(entity, includedTypes);
 		}
 		return putAllow
 			.apply(entity)
@@ -241,6 +261,99 @@ public class Database {
 				return driver.delete(organisationId, entity);
 			});
 	}
+
+	private <T extends Table> CompletableFuture<T> deleteCascade(T entity, Set<Class<? extends Table>> includedTypes) {
+		return reload(entity)
+			.thenApply(current -> current == null ? entity : current)
+			.thenCompose(current -> collectCascadeDeletes(current, includedTypes, new HashSet<>(), new ArrayList<>()))
+			.thenCompose(order -> validateDeletePermissions(order).thenApply(__ -> order))
+			.thenCompose(this::executeCascadeDeletes)
+			.thenApply(__ -> entity);
+	}
+
+	private CompletableFuture<List<Table>> executeCascadeDeletes(List<Table> order) {
+		CompletableFuture<?> future = CompletableFuture.completedFuture(null);
+		for (var item : order) {
+			future = future
+				.thenCompose(
+					__ -> reload(item)
+						.thenCompose(current -> {
+							if (current == null) {
+								return CompletableFuture.completedFuture(null);
+							}
+							return delete(current, true, false).thenApply(ignored -> null);
+						})
+				);
+		}
+		return future.thenApply(__ -> order);
+	}
+
+	private CompletableFuture<Void> validateDeletePermissions(List<Table> order) {
+		return TableCoreUtil
+			.all(
+				order
+					.stream()
+					.map(item -> putAllow.apply(item).thenApply(allow -> {
+						if (!allow) {
+							throw new ForbiddenWriteException(
+								"Delete not allowed for " + TableCoreUtil.table(item.getClass()) + " with id " + item.getId()
+							);
+						}
+						return item;
+					})
+					)
+					.collect(Collectors.toList())
+			)
+			.thenApply(__ -> null);
+	}
+
+	private CompletableFuture<List<Table>> collectCascadeDeletes(
+		Table entity,
+		Set<Class<? extends Table>> includedTypes,
+		Set<CascadeDeleteRef> visited,
+		List<Table> order
+	) {
+		var ref = new CascadeDeleteRef(TableCoreUtil.table(entity.getClass()), entity.getId());
+		if (!visited.add(ref)) {
+			return CompletableFuture.completedFuture(order);
+		}
+
+		return driver
+			.getViaLinks(organisationId, entity, items)
+			.thenCompose(children -> {
+				CompletableFuture<?> future = CompletableFuture.completedFuture(null);
+				for (var child : children) {
+					if (child == null || !isIncluded(child, includedTypes)) {
+						continue;
+					}
+					future = future.thenCompose(__ -> collectCascadeDeletes(child, includedTypes, visited, order));
+				}
+				return future.thenApply(__ -> {
+					order.add(entity);
+					return order;
+				});
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	private Class<? extends Table> baseTableClass(Table entity) {
+		return TableCoreUtil.baseClass((Class<Table>) entity.getClass());
+	}
+
+	private boolean isIncluded(Table entity, Set<Class<? extends Table>> includedTypes) {
+		if (includedTypes.isEmpty()) {
+			return true;
+		}
+		var table = TableCoreUtil.table(baseTableClass(entity));
+		return includedTypes.stream().anyMatch(type -> TableCoreUtil.table(type).equals(table));
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T extends Table> CompletableFuture<T> reload(T entity) {
+		return get((Class<T>) entity.getClass(), entity.getId());
+	}
+
+	private record CascadeDeleteRef(String table, String id) {}
 
 	public <T extends Table> CompletableFuture<List<T>> getLinks(final Table entry, Class<T> target) {
 		return driver

--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DatabaseDriver.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DatabaseDriver.java
@@ -40,6 +40,10 @@ public abstract class DatabaseDriver {
 		TableDataLoader<DatabaseKey<Table>> items
 	);
 
+	public CompletableFuture<List<Table>> getViaLinks(String organisationId, Table entry, TableDataLoader<DatabaseKey<Table>> items) {
+		throw new UnsupportedOperationException("This database driver does not support loading linked entities without an explicit type");
+	}
+
 	public abstract <T extends Table> CompletableFuture<List<T>> query(DatabaseQueryKey<T> key);
 
 	public abstract CompletableFuture<Void> restoreBackup(List<BackupItem> entities);

--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DeleteMode.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DeleteMode.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager;
+
+public enum DeleteMode {
+	REJECT_IF_LINKED,
+	UNLINK_ONLY,
+	CASCADE,
+}

--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DeleteOptions.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/DeleteOptions.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager;
+
+import com.phocassoftware.graphql.database.manager.util.TableCoreUtil;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record DeleteOptions(DeleteMode mode, Set<Class<? extends Table>> includedTypes) {
+
+	public DeleteOptions {
+		Objects.requireNonNull(mode, "mode");
+		includedTypes = includedTypes == null
+			? Set.of()
+			: includedTypes.stream().map(DeleteOptions::normalizeType).collect(Collectors.toUnmodifiableSet());
+	}
+
+	public static DeleteOptions rejectIfLinked() {
+		return new DeleteOptions(DeleteMode.REJECT_IF_LINKED, Set.of());
+	}
+
+	public static DeleteOptions unlinkOnly() {
+		return new DeleteOptions(DeleteMode.UNLINK_ONLY, Set.of());
+	}
+
+	public static DeleteOptions cascade() {
+		return new DeleteOptions(DeleteMode.CASCADE, Set.of());
+	}
+
+	public static DeleteOptions cascade(Set<Class<? extends Table>> includedTypes) {
+		return new DeleteOptions(DeleteMode.CASCADE, includedTypes);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Class<? extends Table> normalizeType(Class<? extends Table> type) {
+		return TableCoreUtil.baseClass((Class<Table>) Objects.requireNonNull(type, "includedTypes entry"));
+	}
+}

--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/VirtualDatabase.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/VirtualDatabase.java
@@ -37,6 +37,10 @@ public class VirtualDatabase {
 		return database.delete(entity, deleteLinks).join();
 	}
 
+	public <T extends Table> T delete(T entity, DeleteOptions options) {
+		return database.delete(entity, options).join();
+	}
+
 	public <T extends Table> List<T> getLinks(final Table entry, Class<T> target) {
 		return database.getLinks(entry, target).join();
 	}

--- a/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
+++ b/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -154,7 +155,13 @@ public class DynamoDb extends DatabaseDriver {
 		if (classPath != null) {
 			java.util.List<Class<Table>> tableObjects;
 			try (var scanResult = new ClassGraph().acceptPackages(classPath).enableClassInfo().scan()) {
-				tableObjects = scanResult.getSubclasses(Table.class).loadClasses(Table.class);
+				tableObjects = scanResult
+					.getAllClasses()
+					.loadClasses()
+					.stream()
+					.filter(clazz -> clazz != Table.class && Table.class.isAssignableFrom(clazz))
+					.map(clazz -> (Class<Table>) clazz)
+					.toList();
 			}
 
 			this.hashKeyExpander = new HashMap<>();
@@ -562,6 +569,30 @@ public class DynamoDb extends DatabaseDriver {
 		Class<Table> query = (Class<Table>) type;
 		List<DatabaseKey<Table>> keys = links.stream().map(link -> createDatabaseKey(organisationId, query, link)).collect(Collectors.toList());
 		return items.loadMany(keys);
+	}
+
+	@Override
+	public CompletableFuture<List<Table>> getViaLinks(String organisationId, Table entry, TableDataLoader<DatabaseKey<Table>> items) {
+		if (getLinks(entry).isEmpty()) {
+			return CompletableFuture.completedFuture(Collections.emptyList());
+		}
+		if (this.classes == null) {
+			throw new UnsupportedOperationException("Cascade delete requires a configured classPath so linked table types can be resolved");
+		}
+
+		List<DatabaseKey<Table>> keys = new ArrayList<>();
+		for (var link : getLinks(entry).entrySet()) {
+			var type = this.classes.get(link.getKey());
+			if (type == null) {
+				throw new RuntimeException("Could not resolve linked table type " + link.getKey());
+			}
+			Class<Table> query = (Class<Table>) type;
+			link.getValue().stream().map(id -> createDatabaseKey(organisationId, query, id)).forEach(keys::add);
+		}
+
+		return items
+			.loadMany(keys)
+			.thenApply(entities -> entities.stream().filter(Objects::nonNull).map(entity -> (Table) entity).collect(Collectors.toList()));
 	}
 
 	@Override

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeChildTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeChildTable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test;
+
+import com.phocassoftware.graphql.database.manager.Table;
+
+public class CascadeChildTable extends Table {
+
+	private String name;
+
+	public CascadeChildTable() {}
+
+	public CascadeChildTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeLeafTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeLeafTable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test;
+
+import com.phocassoftware.graphql.database.manager.Table;
+
+public class CascadeLeafTable extends Table {
+
+	private String name;
+
+	public CascadeLeafTable() {}
+
+	public CascadeLeafTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeRootTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/CascadeRootTable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test;
+
+import com.phocassoftware.graphql.database.manager.Table;
+
+public class CascadeRootTable extends Table {
+
+	private String name;
+
+	public CascadeRootTable() {}
+
+	public CascadeRootTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/DynamoDbLinkTest.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/DynamoDbLinkTest.java
@@ -13,10 +13,12 @@
 package com.phocassoftware.graphql.database.manager.test;
 
 import com.phocassoftware.graphql.database.manager.Database;
+import com.phocassoftware.graphql.database.manager.DeleteOptions;
 import com.phocassoftware.graphql.database.manager.Table;
 import com.phocassoftware.graphql.database.manager.test.annotations.DatabaseNames;
 import com.phocassoftware.graphql.database.manager.test.annotations.DatabaseOrganisation;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Assertions;
 
@@ -117,6 +119,44 @@ final class DynamoDbLinkTest {
 
 		var list = db.getLinks(john, SimpleTable.class).get();
 		Assertions.assertEquals(0, list.size());
+		Assertions.assertNotNull(db.get(AnotherTable.class, john.getId()).get());
+	}
+
+	@TestDatabase
+	void testCascadeDelete(final Database db) throws InterruptedException, ExecutionException {
+		var garry = db.put(new CascadeRootTable("garry")).get();
+		var john = db.put(new CascadeChildTable("john")).get();
+		var jane = db.put(new CascadeLeafTable("jane")).get();
+
+		garry = db.link(garry, john.getClass(), john.getId()).get();
+		john = db.get(CascadeChildTable.class, john.getId()).get();
+		john = db.link(john, jane.getClass(), jane.getId()).get();
+
+		db.delete(garry, DeleteOptions.cascade()).get();
+
+		Assertions.assertNull(db.get(CascadeRootTable.class, garry.getId()).get());
+		Assertions.assertNull(db.get(CascadeChildTable.class, john.getId()).get());
+		Assertions.assertNull(db.get(CascadeLeafTable.class, jane.getId()).get());
+	}
+
+	@TestDatabase
+	void testCascadeDeleteWithIncludedType(final Database db) throws InterruptedException, ExecutionException {
+		var garry = db.put(new CascadeRootTable("garry")).get();
+		var john = db.put(new CascadeChildTable("john")).get();
+		var jane = db.put(new CascadeLeafTable("jane")).get();
+
+		garry = db.link(garry, john.getClass(), john.getId()).get();
+		john = db.get(CascadeChildTable.class, john.getId()).get();
+		john = db.link(john, jane.getClass(), jane.getId()).get();
+
+		db.delete(garry, DeleteOptions.cascade(Set.of(CascadeChildTable.class))).get();
+
+		Assertions.assertNull(db.get(CascadeRootTable.class, garry.getId()).get());
+		Assertions.assertNull(db.get(CascadeChildTable.class, john.getId()).get());
+
+		jane = db.get(CascadeLeafTable.class, jane.getId()).get();
+		Assertions.assertNotNull(jane);
+		Assertions.assertTrue(db.getLinks(jane, CascadeChildTable.class).get().isEmpty());
 	}
 
 	@TestDatabase
@@ -194,6 +234,21 @@ final class DynamoDbLinkTest {
 		public AnotherTable() {}
 
 		public AnotherTable(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	static class ThirdTable extends Table {
+
+		private String name;
+
+		public ThirdTable() {}
+
+		public ThirdTable(String name) {
 			this.name = name;
 		}
 

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeChildTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeChildTable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test.hashed;
+
+import com.phocassoftware.graphql.database.manager.Table;
+import com.phocassoftware.graphql.database.manager.annotations.Hash;
+
+@Hash(SimplerHasher.class)
+public class CascadeChildTable extends Table {
+
+	private String name;
+
+	public CascadeChildTable() {}
+
+	public CascadeChildTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeLeafTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeLeafTable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test.hashed;
+
+import com.phocassoftware.graphql.database.manager.Table;
+import com.phocassoftware.graphql.database.manager.annotations.Hash;
+
+@Hash(SimplerHasher.class)
+public class CascadeLeafTable extends Table {
+
+	private String name;
+
+	public CascadeLeafTable() {}
+
+	public CascadeLeafTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeRootTable.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/CascadeRootTable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.test.hashed;
+
+import com.phocassoftware.graphql.database.manager.Table;
+import com.phocassoftware.graphql.database.manager.annotations.Hash;
+
+@Hash(SimplerHasher.class)
+public class CascadeRootTable extends Table {
+
+	private String name;
+
+	public CascadeRootTable() {}
+
+	public CascadeRootTable(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/DynamoDbLinkTest.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/DynamoDbLinkTest.java
@@ -13,6 +13,7 @@
 package com.phocassoftware.graphql.database.manager.test.hashed;
 
 import com.phocassoftware.graphql.database.manager.Database;
+import com.phocassoftware.graphql.database.manager.DeleteOptions;
 import com.phocassoftware.graphql.database.manager.Table;
 import com.phocassoftware.graphql.database.manager.annotations.Hash;
 import com.phocassoftware.graphql.database.manager.test.TestDatabase;
@@ -21,6 +22,7 @@ import com.phocassoftware.graphql.database.manager.test.annotations.DatabaseOrga
 import org.junit.jupiter.api.Assertions;
 
 import java.util.Comparator;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 final class DynamoDbLinkTest {
@@ -95,6 +97,44 @@ final class DynamoDbLinkTest {
 
 		var list = db.getLinks(john, SimpleTable.class).get();
 		Assertions.assertEquals(0, list.size());
+		Assertions.assertNotNull(db.get(AnotherTable.class, john.getId()).get());
+	}
+
+	@TestDatabase
+	void testCascadeDelete(final Database db) throws InterruptedException, ExecutionException {
+		var garry = db.put(new CascadeRootTable("garry")).get();
+		var john = db.put(new CascadeChildTable("john")).get();
+		var jane = db.put(new CascadeLeafTable("jane")).get();
+
+		garry = db.link(garry, john.getClass(), john.getId()).get();
+		john = db.get(CascadeChildTable.class, john.getId()).get();
+		john = db.link(john, jane.getClass(), jane.getId()).get();
+
+		db.delete(garry, DeleteOptions.cascade()).get();
+
+		Assertions.assertNull(db.get(CascadeRootTable.class, garry.getId()).get());
+		Assertions.assertNull(db.get(CascadeChildTable.class, john.getId()).get());
+		Assertions.assertNull(db.get(CascadeLeafTable.class, jane.getId()).get());
+	}
+
+	@TestDatabase
+	void testCascadeDeleteWithIncludedType(final Database db) throws InterruptedException, ExecutionException {
+		var garry = db.put(new CascadeRootTable("garry")).get();
+		var john = db.put(new CascadeChildTable("john")).get();
+		var jane = db.put(new CascadeLeafTable("jane")).get();
+
+		garry = db.link(garry, john.getClass(), john.getId()).get();
+		john = db.get(CascadeChildTable.class, john.getId()).get();
+		john = db.link(john, jane.getClass(), jane.getId()).get();
+
+		db.delete(garry, DeleteOptions.cascade(Set.of(CascadeChildTable.class))).get();
+
+		Assertions.assertNull(db.get(CascadeRootTable.class, garry.getId()).get());
+		Assertions.assertNull(db.get(CascadeChildTable.class, john.getId()).get());
+
+		jane = db.get(CascadeLeafTable.class, jane.getId()).get();
+		Assertions.assertNotNull(jane);
+		Assertions.assertTrue(db.getLinks(jane, CascadeChildTable.class).get().isEmpty());
 	}
 
 	@TestDatabase
@@ -161,6 +201,22 @@ final class DynamoDbLinkTest {
 		public AnotherTable() {}
 
 		public AnotherTable(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+
+	@Hash(SimplerHasher.class)
+	static class ThirdTable extends Table {
+
+		private String name;
+
+		public ThirdTable() {}
+
+		public ThirdTable(String name) {
 			this.name = name;
 		}
 


### PR DESCRIPTION
## Summary

- Adds a new cascade delete path for linked entities, driven by `DeleteOptions`, so callers can choose between rejecting linked deletes, unlink-only deletes, and true cascading deletes.
- Keeps the existing `delete(entity, true)` behavior as unlink-only for backwards compatibility, while the new cascade mode recursively deletes only the linked entity types the caller explicitly includes.
- Preserves non-included linked entities by unlinking them from deleted parents rather than deleting them.

## Why

Deleting an entity with links previously only cleared the links, which could leave behind child entities that were no longer wanted. This change lets consumers explicitly model ownership by naming the relation types that should be deleted as part of the cascade, while leaving shared or unrelated linked entities intact by default.

## Example Usage

```java
var widget = db.get(Widget.class, widgetId).get();

db.delete(
    widget,
    DeleteOptions.cascade(Set.of(Row.class, Filter.class))
).get();
```

This deletes the `widget` and cascades through linked `Row` and `Filter` entities, while preserving any other linked entity types and unlinking them from the deleted parents.