### PR TITLE
Fix DynamoDb.deleteLinks to derive keys via the @Hash extractor

### DIFF
--- a/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
+++ b/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
@@ -1430,17 +1430,12 @@ public class DynamoDb extends DatabaseDriver {
 		}
 
 		var organisationIdAttribute = AttributeValue.builder().s(organisationId).build();
-		var id = AttributeValue.builder().s(table(entity.getClass()) + ":" + entity.getId()).build();
-		// we first clear out our own object
+		Map<String, AttributeValue> sourceKey = mapWithKeys(organisationId, entity);
 
 		long revision = entity.getRevision();
 		Map<String, AttributeValue> values = new HashMap<>();
 		values.put(":val", AttributeValue.builder().m(new HashMap<>()).build());
 		values.put(":revisionIncrement", REVISION_INCREMENT);
-
-		Map<String, AttributeValue> sourceKey = new HashMap<>();
-		sourceKey.put("organisationId", organisationIdAttribute);
-		sourceKey.put("id", id);
 
 		var clearEntity = client
 			.updateItem(
@@ -1489,10 +1484,15 @@ public class DynamoDb extends DatabaseDriver {
 				.stream()
 				.flatMap(s -> s.getValue().stream().map(v -> Map.entry(s.getKey(), v)))
 				.map(link -> {
-					var targetIdAttribute = AttributeValue.builder().s(link.getKey() + ":" + link.getValue()).build();
-					Map<String, AttributeValue> targetKey = new HashMap<>();
-					targetKey.put("organisationId", organisationIdAttribute);
-					targetKey.put("id", targetIdAttribute);
+					var linkedClass = classes.get(link.getKey());
+					Map<String, AttributeValue> targetKey;
+					if (linkedClass != null) {
+						targetKey = mapWithKeys(organisationId, linkedClass, link.getValue());
+					} else {
+						targetKey = new HashMap<>();
+						targetKey.put("organisationId", organisationIdAttribute);
+						targetKey.put("id", AttributeValue.builder().s(link.getKey() + ":" + link.getValue()).build());
+					}
 
 					Map<String, AttributeValue> v = new HashMap<>();
 					v.put(":val", val);

--- a/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/DynamoDbLinkTest.java
+++ b/graphql-database-manager-test/src/test/java/com/phocassoftware/graphql/database/manager/test/hashed/DynamoDbLinkTest.java
@@ -15,7 +15,6 @@ package com.phocassoftware.graphql.database.manager.test.hashed;
 import com.phocassoftware.graphql.database.manager.Database;
 import com.phocassoftware.graphql.database.manager.Table;
 import com.phocassoftware.graphql.database.manager.annotations.Hash;
-import com.phocassoftware.graphql.database.manager.test.TestDatabase;
 import com.phocassoftware.graphql.database.manager.test.annotations.DatabaseNames;
 import com.phocassoftware.graphql.database.manager.test.annotations.DatabaseOrganisation;
 import org.junit.jupiter.api.Assertions;
@@ -116,6 +115,23 @@ final class DynamoDbLinkTest {
 	}
 
 	@TestDatabase
+	void testDeleteLinksRemovesHashedBackReference(final Database db) throws InterruptedException, ExecutionException {
+		var garry = db.put(new SimpleTable("garry")).get();
+		var john = db.put(new AnotherTable("john")).get();
+
+		garry = db.link(garry, john.getClass(), john.getId()).get();
+
+		john = db.get(AnotherTable.class, john.getId()).get();
+		Assertions.assertEquals(1, db.getLinks(john, SimpleTable.class).get().size());
+
+		db.deleteLinks(garry).get();
+
+		john = db.get(AnotherTable.class, john.getId()).get();
+		var list = db.getLinks(john, SimpleTable.class).get();
+		Assertions.assertEquals(0, list.size());
+	}
+
+	@TestDatabase
 	void unlink(final Database db) throws InterruptedException, ExecutionException {
 		var garry = db.put(new SimpleTable("garry")).get();
 		var bob = db.put(new AnotherTable("bob")).get();
@@ -138,7 +154,7 @@ final class DynamoDbLinkTest {
 	}
 
 	@Hash(SimplerHasher.class)
-	static class SimpleTable extends Table {
+	public static class SimpleTable extends Table {
 
 		private String name;
 
@@ -154,7 +170,7 @@ final class DynamoDbLinkTest {
 	}
 
 	@Hash(SimplerHasher.class)
-	static class AnotherTable extends Table {
+	public static class AnotherTable extends Table {
 
 		private String name;
 


### PR DESCRIPTION
## Problem

`DynamoDb.deleteLinks` built DynamoDB keys by hand using the 2-component format (raw `organisationId`, `table:id`), ignoring `@Hash`. This happened in two places:

1. **Clearing the source entity's own links** — for a hashed entity this targeted the wrong key, so the revision condition failed with `RevisionMismatchException`.
2. **Removing the back-references on each linked entity** — these were never deleted because the UpdateItem targeted a non-existent (phantom) key.

`get`/`put`/`query` all route through `mapWithKeys`, which is `@Hash`-aware, so `deleteLinks` was inconsistent with the rest of the driver.

## Fix

Both the source key and the linked-entity key now derive through `mapWithKeys` — the same extractor-aware path `get`/`put`/`query` use. The stored link table name is resolved back to its class via the existing `classes` map; the legacy 2-component key is kept only as a fallback for tables not on the classpath.