### PR TITLE
Add DynamoDB time-to-live annotation

### DIFF
--- a/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/annotations/TimeToLive.java
+++ b/graphql-database-manager-core/src/main/java/com/phocassoftware/graphql/database/manager/annotations/TimeToLive.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.phocassoftware.graphql.database.manager.annotations;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an {@link java.time.Instant} field as the expiry time for a database
+ * entry.
+ */
+@Retention(RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TimeToLive {}

--- a/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
+++ b/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDb.java
@@ -428,6 +428,11 @@ public class DynamoDb extends DatabaseDriver {
 			var index = AttributeValue.builder().s(table(entity.getClass()) + ":" + secondaryOrganisation).build();
 			item.put("secondaryOrganisation", index);
 		}
+
+		var timeToLive = TableUtil.getTimeToLive(entity);
+		if (timeToLive != null) {
+			item.put("ttl", AttributeValue.builder().n(Long.toString(timeToLive.getEpochSecond())).build());
+		}
 		return item;
 	}
 

--- a/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/TableUtil.java
+++ b/graphql-database-manager-dynamo/src/main/java/com/phocassoftware/graphql/database/manager/dynamo/TableUtil.java
@@ -26,7 +26,10 @@ import tools.jackson.databind.node.POJONode;
 import com.phocassoftware.graphql.database.manager.Table;
 import com.phocassoftware.graphql.database.manager.annotations.GlobalIndex;
 import com.phocassoftware.graphql.database.manager.annotations.SecondaryIndex;
+import com.phocassoftware.graphql.database.manager.annotations.TimeToLive;
 import com.phocassoftware.graphql.database.manager.util.BackupItem;
+import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,6 +47,37 @@ import software.amazon.awssdk.core.util.DefaultSdkAutoConstructMap;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class TableUtil {
+
+	static Instant getTimeToLive(Table entity) {
+		Field timeToLiveField = null;
+		Class<?> type = entity.getClass();
+
+		while (type != null) {
+			for (var field : type.getDeclaredFields()) {
+				if (field.isAnnotationPresent(TimeToLive.class)) {
+					if (timeToLiveField != null) {
+						throw new IllegalArgumentException("Only one field can be annotated with @TimeToLive");
+					}
+					timeToLiveField = field;
+				}
+			}
+			type = type.getSuperclass();
+		}
+
+		if (timeToLiveField == null) {
+			return null;
+		}
+		if (!timeToLiveField.getType().equals(Instant.class)) {
+			throw new IllegalArgumentException("@TimeToLive can only be used on an Instant field");
+		}
+
+		try {
+			timeToLiveField.trySetAccessible();
+			return (Instant) timeToLiveField.get(entity);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("Unable to read @TimeToLive field", e);
+		}
+	}
 
 	static String getSecondaryGlobal(Table entity) {
 		for (var method : entity.getClass().getMethods()) {

--- a/graphql-database-manager-dynamo/src/test/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDbTest.java
+++ b/graphql-database-manager-dynamo/src/test/java/com/phocassoftware/graphql/database/manager/dynamo/DynamoDbTest.java
@@ -13,7 +13,14 @@
 package com.phocassoftware.graphql.database.manager.dynamo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import tools.jackson.databind.ObjectMapper;
+import com.phocassoftware.graphql.database.manager.Table;
+import com.phocassoftware.graphql.database.manager.annotations.TimeToLive;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +32,63 @@ public class DynamoDbTest {
 		assertEquals("11000011", DynamoDb.parallelHash("1234"));
 		assertEquals("00010111", DynamoDb.parallelHash("2"));
 		assertEquals(8, DynamoDb.parallelHash(UUID.randomUUID().toString()).length());
+	}
+
+	@Test
+	public void testTimeToLiveCopiedToTopLevelAsEpochSeconds() {
+		var expiresAt = Instant.parse("2026-07-20T12:34:56.789Z");
+		var entity = new ExpiringTable(expiresAt);
+		entity.setId("entry");
+
+		var item = dynamoDb().buildPutEntity("organisation", entity, false);
+
+		assertEquals(Long.toString(expiresAt.getEpochSecond()), item.get("ttl").n());
+		assertEquals(expiresAt.toString(), item.get("item").m().get("expiresAt").s());
+	}
+
+	@Test
+	public void testNullTimeToLiveIsNotCopiedToTopLevel() {
+		var entity = new ExpiringTable(null);
+		entity.setId("entry");
+
+		var item = dynamoDb().buildPutEntity("organisation", entity, false);
+
+		assertFalse(item.containsKey("ttl"));
+	}
+
+	@Test
+	public void testTimeToLiveMustAnnotateAnInstant() {
+		var entity = new InvalidExpiringTable();
+		entity.setId("entry");
+
+		assertThrows(IllegalArgumentException.class, () -> dynamoDb().buildPutEntity("organisation", entity, false));
+	}
+
+	private DynamoDb dynamoDb() {
+		return new DynamoDb(new ObjectMapper(), List.of("table"), List.of(), null, () -> "id");
+	}
+
+	static class ExpiringTable extends Table {
+
+		@TimeToLive
+		private Instant expiresAt;
+
+		ExpiringTable(Instant expiresAt) {
+			this.expiresAt = expiresAt;
+		}
+
+		public Instant getExpiresAt() {
+			return expiresAt;
+		}
+	}
+
+	static class InvalidExpiringTable extends Table {
+
+		@TimeToLive
+		private String expiresAt;
+
+		public String getExpiresAt() {
+			return expiresAt;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- add a `@TimeToLive` annotation for `Instant` entity fields
- copy the annotated value to the top-level DynamoDB `ttl` attribute as epoch seconds
- omit null TTL values and validate invalid or duplicate annotations
- cover TTL serialization and validation with unit tests

## Testing

- `mvn -pl graphql-database-manager-dynamo -am test`
- `mvn -pl graphql-database-manager-core,graphql-database-manager-dynamo formatter:validate`