### PR TITLE
Fix NPE scanning repeatable @Restrict in getGlobalRestricts

### DIFF
--- a/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
+++ b/graphql-builder/src/main/java/com/phocassoftware/graphql/builder/SchemaBuilder.java
@@ -232,6 +232,11 @@ public class SchemaBuilder {
 
 			for (var r : restrict) {
 				Restrict annotation = EntityUtil.getAnnotation(r, Restrict.class);
+				if (annotation == null) {
+					// Class carries repeatable @Restrict via the @Restricts container: classgraph reports it
+					// under Restrict, but the direct annotation is absent. Handled by the container loop below.
+					continue;
+				}
 				var factoryClass = annotation.value();
 				var factory = factoryClass.getConstructor().newInstance();
 				if (!factory.extractType().isAssignableFrom(r)) {

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/repeatablerestrict/RepeatableRestrictEntity.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/repeatablerestrict/RepeatableRestrictEntity.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.repeatablerestrict;
+
+import com.phocassoftware.graphql.builder.RestrictType;
+import com.phocassoftware.graphql.builder.RestrictTypeFactory;
+import com.phocassoftware.graphql.builder.annotations.Entity;
+import com.phocassoftware.graphql.builder.annotations.Query;
+import com.phocassoftware.graphql.builder.annotations.Restrict;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Exercises a class carrying more than one {@link Restrict} annotation. Java folds the repeated
+ * annotation into the {@code @Restricts} container, which classgraph reports under both {@code Restrict}
+ * and {@code Restricts}; the schema build must handle that without failing.
+ */
+@Entity
+@Restrict(RepeatableRestrictEntity.FirstRestrictor.class)
+@Restrict(RepeatableRestrictEntity.SecondRestrictor.class)
+public class RepeatableRestrictEntity {
+
+	private final boolean value;
+
+	public RepeatableRestrictEntity(boolean value) {
+		this.value = value;
+	}
+
+	public boolean isValue() {
+		return value;
+	}
+
+	@Query
+	public static RepeatableRestrictEntity entity() {
+		return new RepeatableRestrictEntity(true);
+	}
+
+	public static class FirstRestrictor implements RestrictTypeFactory<RepeatableRestrictEntity>, RestrictType<RepeatableRestrictEntity> {
+
+		@Override
+		public CompletableFuture<RestrictType<RepeatableRestrictEntity>> create(DataFetchingEnvironment context) {
+			return CompletableFuture.completedFuture(this);
+		}
+
+		@Override
+		public CompletableFuture<Boolean> allow(RepeatableRestrictEntity obj) {
+			return CompletableFuture.completedFuture(true);
+		}
+	}
+
+	public static class SecondRestrictor implements RestrictTypeFactory<RepeatableRestrictEntity>, RestrictType<RepeatableRestrictEntity> {
+
+		@Override
+		public CompletableFuture<RestrictType<RepeatableRestrictEntity>> create(DataFetchingEnvironment context) {
+			return CompletableFuture.completedFuture(this);
+		}
+
+		@Override
+		public CompletableFuture<Boolean> allow(RepeatableRestrictEntity obj) {
+			return CompletableFuture.completedFuture(true);
+		}
+	}
+}

--- a/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/repeatablerestrict/RepeatableRestrictTest.java
+++ b/graphql-builder/src/test/java/com/phocassoftware/graphql/builder/repeatablerestrict/RepeatableRestrictTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.phocassoftware.graphql.builder.repeatablerestrict;
+
+import com.phocassoftware.graphql.builder.SchemaBuilder;
+import graphql.GraphQL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RepeatableRestrictTest {
+
+	/*
+	 * Regression: a class annotated with more than one @Restrict is stored in the @Restricts container.
+	 * classgraph reports such a class under @Restrict too, but the direct annotation is absent, so the
+	 * global-restrict scan must not assume getAnnotation(Restrict.class) is non-null.
+	 */
+	@Test
+	public void buildsSchemaWithRepeatableRestrict() throws ReflectiveOperationException {
+		var schema = GraphQL
+			.newGraphQL(SchemaBuilder.build("com.phocassoftware.graphql.builder.repeatablerestrict"))
+			.build();
+
+		var result = schema.execute("query { entity { __typename } }");
+
+		Assertions.assertTrue(result.getErrors().isEmpty(), () -> result.getErrors().toString());
+	}
+}


### PR DESCRIPTION
## What

`SchemaBuilder.getGlobalRestricts` throws `NullPointerException` when a class carries more than one `@Restrict`. Guard against the null direct-annotation case in the single-annotation loop, and add a regression test.

## Why

A class with multiple `@Restrict` stores them in the `@Restricts` container. This regressed in #181 ("Replace Reflections with ClassGraph for classpath scanning", commit `b652063`, first released in 2.0.1): classgraph's `getClassesWithAnnotation(Restrict.class)` unrolls the repeatable container, so such a class is reported under **both** `@Restrict` and `@Restricts`. The single-annotation loop then calls JDK `EntityUtil.getAnnotation(r, Restrict.class)`, which does not unwrap repeatables and returns `null`, so `annotation.value()` NPEs.

Under the previous org.reflections scanner the two sets were disjoint (container-only classes appeared solely under `@Restricts`), so the bug stayed latent — it only surfaces for a consumer using repeatable `@Restrict`. The container loop already handles those factories, so the fix simply skips the null case.

The added `RepeatableRestrictTest` NPEs without the guard and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
